### PR TITLE
[codex] Prepare Recite for public contributors

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,5 @@
+# Keep older Justin author aliases grouped under the public GitHub identity.
+# Claude and Josh contributor identities are intentionally left unchanged.
+r3dbars <r3dbars@users.noreply.github.com> Justin Betker <jbetker91@gmail.com>
+r3dbars <r3dbars@users.noreply.github.com> justinbetker <Justin.betker@jamf.com>
+r3dbars <r3dbars@users.noreply.github.com> r3dbars <tz427gsydr@privaterelay.appleid.com>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# Recite Agent Notes
+
+Recite is a small macOS menu bar app that reads selected text aloud with Kokoro 82M through `mlx-audio-swift`. It is meant to stay local-first, simple, and easy for a new reader to understand.
+
+## Quick Context
+
+- Entry point: `Recite/Sources/Recite/ReciteApp.swift`
+- App lifecycle, menu bar item, popover, hotkey: `AppDelegate.swift`
+- Text capture: `TextGrabber.swift`
+- TTS model loading and playback: `SpeechEngine.swift`
+- Queue and local history: `ReadingQueue.swift`
+- SwiftUI views: `MenuBarView.swift`
+- App metadata and entitlements: `Recite/Resources/`
+
+## Local Setup
+
+1. Run `git submodule update --init --recursive`.
+2. Install `espeak-ng` with `brew install espeak-ng`.
+3. Run `swift build`.
+4. Run `./scripts/build-and-run.sh` to assemble and launch a local app bundle.
+
+## Guardrails
+
+- Keep text and audio local. Do not add network services for user text, selected text, clipboard text, or generated audio.
+- Do not log selected text, clipboard text, or generated text snippets. Counts and states are fine.
+- Preserve the user's clipboard when using the copy fallback.
+- Keep public docs plain and short. Assume the reader is seeing the repo for the first time.
+- Keep the build script developer-friendly. Use ad-hoc signing by default and only use a real signing identity when `RECITE_CODESIGN_IDENTITY` is set.
+
+## Verification
+
+- Run `swift build` after code changes.
+- There are no test targets yet, so note that in handoffs.
+- For contributor display cleanup, verify with `git log --use-mailmap --format='%aN <%aE>' --all | sort | uniq -c | sort -nr`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing
+
+Thanks for taking a look at Recite.
+
+## Development Setup
+
+```bash
+git submodule update --init --recursive
+brew install espeak-ng
+swift build
+./scripts/build-and-run.sh
+```
+
+The script builds a local `Recite.app`, signs it ad-hoc by default, and launches it.
+
+## What To Keep In Mind
+
+- Recite is local-first. Selected text, clipboard text, and generated audio should stay on the Mac.
+- Avoid logging user text. Log counts, states, and errors instead.
+- Keep UI copy short and plain.
+- Keep changes small when possible.
+
+## Pull Requests
+
+Before opening a PR, run:
+
+```bash
+swift build
+```
+
+There are no automated tests yet, so please include a short manual test note when a change affects text capture, queue behavior, model loading, or playback.

--- a/README.md
+++ b/README.md
@@ -1,62 +1,76 @@
 # Recite
 
-**Recite** is a lightweight, on-device Mac utility that reads anything aloud — articles, emails, Slack messages, docs — using Kokoro 82M, a fast neural text-to-speech model. No cloud. No subscription. No audio sent anywhere.
+Recite is a small Mac app that reads selected text aloud with an on-device neural voice.
 
-Select text in any app, hit your hotkey, and Recite reads it back to you.
+Select text in any app, press **Control + Option + R**, and Recite speaks it back. The text stays on your Mac.
 
----
+## What It Does
 
-## Why
-
-On-device TTS on Apple Silicon is now fast enough to feel instant. Your audio stays on your Mac, there's no subscription, and nothing is sent to any server. Recite is the reader that should have always existed.
-
----
-
-## Features
-
-- **Read anything** — select text in any app and Recite reads it aloud
-- **Natural voice** — powered by Kokoro 82M (bf16) via MLX
-- **100% on-device** — nothing sent to any server, ever
-- **Global hotkey** — press ⌃⌥R from anywhere
-- **Menu bar + main window** — quick controls in the menu bar, full controls in the app window
-- **Reading queue** — queue up articles and listen continuously
-- **Variable speed** — 0.5x to 2x playback
-
----
-
-## How it works
-
-Recite uses [Kokoro 82M](https://huggingface.co/mlx-community/Kokoro-82M-bf16) via [mlx-audio-swift](https://github.com/r3dbars/mlx-audio-swift), running entirely on-device through Apple's MLX framework on Apple Silicon. The model downloads once, then everything runs locally — fast, private, and free.
-
----
+- Reads selected text from almost any Mac app
+- Runs Kokoro 82M locally through Apple MLX
+- Keeps selected text and generated audio on-device
+- Lives in the menu bar
+- Supports a reading queue, history, voices, and playback speed
 
 ## Requirements
 
-- macOS 14+ (Sonoma)
-- Apple Silicon (M1 or later)
-- Xcode with Swift 6.2+
+- macOS 14 or newer
+- Apple Silicon Mac
+- Xcode / Swift toolchain
+- Homebrew `espeak-ng`
 
----
+## Quick Start
 
-## Setup
+```bash
+git clone https://github.com/r3dbars/recite.git
+cd recite
+git submodule update --init --recursive
+brew install espeak-ng
+swift build
+./scripts/build-and-run.sh
+```
 
-See [SETUP.md](SETUP.md) for step-by-step Xcode project setup.
+On first launch, Recite downloads the Kokoro model from Hugging Face. After that, speech generation runs locally.
 
----
+## Using The App
 
-## Tech Stack
+1. Launch Recite.
+2. Grant Accessibility permission when macOS asks.
+3. Select text in another app.
+4. Press **Control + Option + R**.
 
-- Swift / SwiftUI
-- [mlx-audio-swift](https://github.com/r3dbars/mlx-audio-swift) — on-device TTS via MLX
-- [Kokoro 82M](https://huggingface.co/mlx-community/Kokoro-82M-bf16) — compact neural TTS model
-- macOS 14+ / Apple Silicon
+You can also use the menu bar icon to read clipboard text, open the main window, pause playback, or manage the queue.
 
----
+## How It Works
+
+Recite uses:
+
+- Swift and SwiftUI for the Mac app
+- Accessibility APIs to read selected text
+- A clipboard fallback when selection APIs are not available
+- `mlx-audio-swift` for Kokoro 82M text-to-speech
+- `AVAudioEngine` for local playback and speed control
+
+Main files:
+
+- `AppDelegate.swift` handles launch, menu bar, hotkey, and windows
+- `TextGrabber.swift` captures selected text
+- `SpeechEngine.swift` loads Kokoro and plays generated audio
+- `ReadingQueue.swift` manages queue and history
+- `MenuBarView.swift` contains the SwiftUI interface
+
+## Privacy
+
+Recite is built to be local-first. It does not send selected text or generated audio to a server.
+
+The model is downloaded from Hugging Face on first launch. Reading history is stored locally in macOS user defaults and can be cleared in the app.
+
+## Development
+
+See [SETUP.md](SETUP.md) for a fuller local setup guide.
+
+For contribution notes, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 
-MIT — free forever, open source forever.
-
----
-
-*Part of the [r3dbars](https://github.com/r3dbars) suite of on-device voice utilities for Mac.*
+MIT

--- a/Recite/Sources/Recite/AppDelegate.swift
+++ b/Recite/Sources/Recite/AppDelegate.swift
@@ -278,7 +278,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                     }
                 }
             } else {
-                log.warning("No text found from selection (text=\(text ?? "nil"))")
+                log.warning("No text found from selection")
                 await MainActor.run { showPopover() }
             }
         }

--- a/Recite/Sources/Recite/MenuBarView.swift
+++ b/Recite/Sources/Recite/MenuBarView.swift
@@ -1,29 +1,7 @@
 import SwiftUI
 import AppKit
 
-// MARK: - Always-visible button style (unaffected by window key state)
-
-struct AlwaysVisibleButtonStyle: ButtonStyle {
-    let prominent: Bool
-
-    func makeBody(configuration: Configuration) -> some View {
-        configuration.label
-            .font(.system(size: 14, weight: .medium))
-            .padding(.vertical, 9)
-            .padding(.horizontal, 16)
-            .frame(maxWidth: .infinity)
-            .background(prominent ? Color.accentColor : Color(NSColor.controlColor))
-            .foregroundColor(prominent ? .white : .primary)
-            .clipShape(RoundedRectangle(cornerRadius: 8))
-            .overlay(
-                RoundedRectangle(cornerRadius: 8)
-                    .stroke(Color(NSColor.separatorColor), lineWidth: prominent ? 0 : 0.5)
-            )
-            .opacity(configuration.isPressed ? 0.8 : 1.0)
-    }
-}
-
-// MARK: - Menu Bar Popover (compact dark panel, Transcripted-style)
+// MARK: - Menu Bar Popover
 
 struct MenuBarPopoverView: View {
     @StateObject private var engine = SpeechEngine.shared
@@ -285,7 +263,6 @@ enum RecitePanel: String, Hashable, CaseIterable {
 
 struct ReciteSidebar: View {
     @Binding var selection: RecitePanel
-    @StateObject private var engine = SpeechEngine.shared
 
     var body: some View {
         VStack(spacing: 0) {
@@ -508,7 +485,7 @@ struct PlayerDetailView: View {
                         icon: "terminal",
                         label: "espeak-ng",
                         detail: "Text preprocessing — brew install espeak-ng",
-                        status: FileManager.default.fileExists(atPath: "/opt/homebrew/bin/espeak-ng")
+                        status: EspeakTextProcessor.installedExecutablePath != nil
                             ? .ready("Ready") : .warning("Not installed")
                     )
                 }
@@ -558,7 +535,7 @@ struct PlayerDetailView: View {
     }
 }
 
-// MARK: - Action Card (Transcripted-style row with icon + chevron)
+// MARK: - Action Card
 
 struct ActionCard: View {
     let icon: String
@@ -619,7 +596,7 @@ struct ActionCard: View {
     }
 }
 
-// MARK: - Ready Check Row (Transcripted-style)
+// MARK: - Ready Check Row
 
 struct ReadyCheckRow: View {
     enum Status {
@@ -973,7 +950,7 @@ struct AboutDetailView: View {
                             AboutRequirement(met: true, text: "Apple Silicon Mac (M1 or later)")
                             AboutRequirement(met: true, text: "macOS 14 Sonoma or later")
                             AboutRequirement(
-                                met: FileManager.default.fileExists(atPath: "/opt/homebrew/bin/espeak-ng"),
+                                met: EspeakTextProcessor.installedExecutablePath != nil,
                                 text: "espeak-ng  —  brew install espeak-ng"
                             )
                         }
@@ -1081,7 +1058,6 @@ private struct AboutRequirement: View {
 
 struct QueueDetailView: View {
     @StateObject private var queue  = ReadingQueue.shared
-    @StateObject private var engine = SpeechEngine.shared
 
     var body: some View {
         VStack(spacing: 0) {

--- a/Recite/Sources/Recite/ReadingQueue.swift
+++ b/Recite/Sources/Recite/ReadingQueue.swift
@@ -19,7 +19,7 @@ class ReadingQueue: ObservableObject {
             text.split(separator: " ").count
         }
         var estimatedMinutes: Int {
-            max(1, wordCount / 180) // ~180 wpm reading speed
+            max(1, (wordCount + 179) / 180) // ~180 wpm reading speed
         }
     }
 

--- a/Recite/Sources/Recite/SpeechEngine.swift
+++ b/Recite/Sources/Recite/SpeechEngine.swift
@@ -9,9 +9,10 @@ import os.log
 private let log = Logger(subsystem: "com.r3dbars.recite", category: "SpeechEngine")
 
 struct VoicePreset: Identifiable, Hashable {
-    let id = UUID()
     let name: String
     let kokoroVoice: String
+
+    var id: String { kokoroVoice }
 
     static let defaultPreset = VoicePreset(
         name: "Heart",
@@ -19,21 +20,61 @@ struct VoicePreset: Identifiable, Hashable {
     )
 }
 
+private enum EspeakTextProcessorError: LocalizedError {
+    case missingExecutable
+    case failed(status: Int32, stderr: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingExecutable:
+            return "espeak-ng was not found. Install it with `brew install espeak-ng`."
+        case let .failed(status, stderr):
+            if stderr.isEmpty {
+                return "espeak-ng exited with status \(status)."
+            }
+            return "espeak-ng exited with status \(status): \(stderr)"
+        }
+    }
+}
+
 /// espeak-ng based text processor for converting plain text to IPA phonemes.
 struct EspeakTextProcessor: TextProcessor {
+    private static let executablePaths = [
+        "/opt/homebrew/bin/espeak-ng",
+        "/usr/local/bin/espeak-ng",
+        "/usr/bin/espeak-ng",
+    ]
+
+    static var installedExecutablePath: String? {
+        executablePaths.first { FileManager.default.isExecutableFile(atPath: $0) }
+    }
+
     func process(text: String, language: String?) throws -> String {
         let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/opt/homebrew/bin/espeak-ng")
+        guard let executablePath = Self.installedExecutablePath else {
+            throw EspeakTextProcessorError.missingExecutable
+        }
+
+        process.executableURL = URL(fileURLWithPath: executablePath)
         process.arguments = ["--ipa", "-q", text]
 
         let pipe = Pipe()
+        let errorPipe = Pipe()
         process.standardOutput = pipe
-        process.standardError = Pipe()
+        process.standardError = errorPipe
 
         try process.run()
         process.waitUntilExit()
 
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+        let stderr = String(data: errorData, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+        guard process.terminationStatus == 0 else {
+            throw EspeakTextProcessorError.failed(status: process.terminationStatus, stderr: stderr)
+        }
+
         let ipa = String(data: data, encoding: .utf8)?
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
 
@@ -62,7 +103,15 @@ class SpeechEngine: NSObject, ObservableObject {
     @Published var modelStatus: ModelStatus = .notLoaded
     @Published var currentText: String = ""
     @Published var progress: Double = 0
-    @Published var speed: Double = 1.0  // 0.5x – 2.0x playback speed
+    @Published var speed: Double = {
+        let saved = UserDefaults.standard.double(forKey: "playbackSpeed")
+        guard saved >= 0.5, saved <= 2.0 else { return 1.0 }
+        return saved
+    }() {
+        didSet {
+            UserDefaults.standard.set(speed, forKey: "playbackSpeed")
+        }
+    }
     @Published var selectedVoice: String = UserDefaults.standard.string(forKey: "selectedVoice")
         ?? VoicePreset.defaultPreset.kokoroVoice {
         didSet {
@@ -158,6 +207,9 @@ class SpeechEngine: NSObject, ObservableObject {
             self.model = loaded
             modelStatus = .ready
             log.info("Kokoro model loaded successfully")
+            if state == .idle, let item = ReadingQueue.shared.currentItem {
+                speak(item.text)
+            }
         } catch {
             log.error("Model load failed: \(error.localizedDescription)")
             modelStatus = .error(error.localizedDescription)
@@ -217,7 +269,7 @@ class SpeechEngine: NSObject, ObservableObject {
                     let trimmed = sentence.trimmingCharacters(in: .whitespacesAndNewlines)
                     guard !trimmed.isEmpty else { continue }
 
-                    log.info("Generating sentence \(i+1)/\(sentences.count): \(String(trimmed.prefix(50)))...")
+                    log.info("Generating sentence \(i+1)/\(sentences.count) (\(trimmed.count) chars)")
 
                     let params = GenerateParameters()
                     let audio = try await model.generate(
@@ -268,6 +320,7 @@ class SpeechEngine: NSObject, ObservableObject {
                         guard self.generationID == myGenID else { return }
                         state = .idle
                         currentText = ""
+                        progress = 0
                     }
                 }
             }
@@ -397,14 +450,25 @@ class SpeechEngine: NSObject, ObservableObject {
     }
 
     private func playAudio(_ samples: [Float]) {
-        setupAudioEngine()
-        guard let player = playerNode, let format = audioFormat else { return }
+        guard setupAudioEngine(), let player = playerNode, let format = audioFormat else {
+            state = .idle
+            progress = 0
+            return
+        }
 
         let frameCount = AVAudioFrameCount(samples.count)
-        guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount) else { return }
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount) else {
+            state = .idle
+            progress = 0
+            return
+        }
         buffer.frameLength = frameCount
 
-        let channelData = buffer.floatChannelData![0]
+        guard let channelData = buffer.floatChannelData?[0] else {
+            state = .idle
+            progress = 0
+            return
+        }
         for i in 0..<samples.count {
             channelData[i] = max(-1.0, min(1.0, samples[i]))
         }
@@ -440,7 +504,7 @@ class SpeechEngine: NSObject, ObservableObject {
         }
     }
 
-    private func setupAudioEngine() {
+    private func setupAudioEngine() -> Bool {
         let engine = AVAudioEngine()
         let player = AVAudioPlayerNode()
         let timePitch = AVAudioUnitTimePitch()
@@ -459,8 +523,10 @@ class SpeechEngine: NSObject, ObservableObject {
             self.timePitchNode = timePitch
             self.audioFormat = format
             log.info("Audio engine started (speed: \(self.speed)x)")
+            return true
         } catch {
             log.error("Failed to start audio engine: \(error.localizedDescription)")
+            return false
         }
     }
 
@@ -518,8 +584,9 @@ class SpeechEngine: NSObject, ObservableObject {
     }
 
     func updateSpeed(_ newSpeed: Double) {
-        speed = newSpeed
-        timePitchNode?.rate = Float(newSpeed)
-        log.info("Speed updated to \(newSpeed)x")
+        let clampedSpeed = min(max(newSpeed, 0.5), 2.0)
+        speed = clampedSpeed
+        timePitchNode?.rate = Float(clampedSpeed)
+        log.info("Speed updated to \(clampedSpeed)x")
     }
 }

--- a/Recite/Sources/Recite/TextGrabber.swift
+++ b/Recite/Sources/Recite/TextGrabber.swift
@@ -5,6 +5,25 @@ import os.log
 
 private let log = Logger(subsystem: "com.r3dbars.recite", category: "TextGrabber")
 
+private struct ClipboardItemSnapshot {
+    let contents: [(NSPasteboard.PasteboardType, Data)]
+
+    init(item: NSPasteboardItem) {
+        contents = item.types.compactMap { type in
+            guard let data = item.data(forType: type) else { return nil }
+            return (type, data)
+        }
+    }
+
+    func makePasteboardItem() -> NSPasteboardItem {
+        let item = NSPasteboardItem()
+        for (type, data) in contents {
+            item.setData(data, forType: type)
+        }
+        return item
+    }
+}
+
 /// Grabs selected text from the frontmost application.
 /// Strategy:
 ///   1. Try Accessibility API (AXSelectedText) — fast, no clipboard side-effects
@@ -14,14 +33,6 @@ class TextGrabber: ObservableObject {
     static let shared = TextGrabber()
 
     // MARK: - Public
-
-    /// Call this synchronously from the hotkey handler to capture the source app
-    /// before any async work or focus changes.
-    func captureSourceApp() -> pid_t? {
-        let app = NSWorkspace.shared.frontmostApplication
-        log.info("Captured source app: \(app?.localizedName ?? "none") (pid \(app?.processIdentifier ?? 0))")
-        return app?.processIdentifier
-    }
 
     func getSelectedText(fromPID pid: pid_t?) async -> String? {
         log.info("getSelectedText(fromPID: \(pid ?? 0)) called")
@@ -88,14 +99,18 @@ class TextGrabber: ObservableObject {
             log.warning("Failed to get focused element: AXError code \(focusResult.rawValue)")
             return nil
         }
+        guard CFGetTypeID(element) == AXUIElementGetTypeID() else {
+            log.warning("Focused accessibility element had an unexpected type")
+            return nil
+        }
+        let axElement = element as! AXUIElement
 
-        // Log the role of the focused element
         var role: AnyObject?
-        AXUIElementCopyAttributeValue(element as! AXUIElement, kAXRoleAttribute as CFString, &role)
+        AXUIElementCopyAttributeValue(axElement, kAXRoleAttribute as CFString, &role)
         log.info("Focused element role: \(role as? String ?? "unknown")")
 
         var selectedText: AnyObject?
-        let textResult = AXUIElementCopyAttributeValue(element as! AXUIElement,
+        let textResult = AXUIElementCopyAttributeValue(axElement,
                                                         kAXSelectedTextAttribute as CFString,
                                                         &selectedText)
         guard textResult == .success else {
@@ -104,7 +119,7 @@ class TextGrabber: ObservableObject {
         }
 
         let text = selectedText as? String
-        log.info("AX selected text: \(text ?? "nil") (\(text?.count ?? 0) chars)")
+        log.info("AX selected text length: \(text?.count ?? 0) chars")
         return text
     }
 
@@ -114,11 +129,8 @@ class TextGrabber: ObservableObject {
         let pasteboard = NSPasteboard.general
         log.info("Starting clipboard simulation")
 
-        // Save current clipboard content for restoration later
-        let savedStrings = pasteboard.pasteboardItems?.compactMap {
-            $0.string(forType: .string)
-        }
-        log.info("Saved clipboard items=\(savedStrings?.count ?? 0)")
+        let savedItems = pasteboard.pasteboardItems?.map(ClipboardItemSnapshot.init) ?? []
+        log.info("Saved clipboard items=\(savedItems.count)")
 
         // Clear clipboard FIRST, then save the changeCount.
         // clearContents() itself increments changeCount, so we must save AFTER
@@ -158,8 +170,7 @@ class TextGrabber: ObservableObject {
 
         // Check all common text types — Chrome often copies as rich text without plain text
         let types = pasteboard.types ?? []
-        let typeNames = types.map(\.rawValue).joined(separator: ", ")
-        log.warning("Clipboard types: \(typeNames, privacy: .public)")
+        log.info("Clipboard changed with \(types.count) type(s)")
 
         // Try multiple pasteboard types in order of preference
         let textTypes: [NSPasteboard.PasteboardType] = [
@@ -182,8 +193,7 @@ class TextGrabber: ObservableObject {
         if grabbed == nil {
             if let items = pasteboard.pasteboardItems {
                 for item in items {
-                    let itemTypeNames = item.types.map(\.rawValue).joined(separator: ", ")
-                    log.warning("Pasteboard item types: \(itemTypeNames, privacy: .public)")
+                    log.info("Checking pasteboard item with \(item.types.count) type(s)")
                     for type in item.types {
                         if let text = item.string(forType: type), !text.isEmpty {
                             // Skip HTML markup, prefer plain text
@@ -208,15 +218,16 @@ class TextGrabber: ObservableObject {
             }
         }
 
-        let grabSummary = grabbed != nil ? "\(grabbed!.count) chars: \(String(grabbed!.prefix(80)))" : "nil"
-        log.warning("Grabbed from clipboard: \(grabSummary, privacy: .public) (changeCount=\(pasteboard.changeCount), polls=\(pollCount))")
+        if let grabbed {
+            log.info("Grabbed text from clipboard (\(grabbed.count) chars, polls=\(pollCount))")
+        } else {
+            log.info("No text grabbed from clipboard (polls=\(pollCount))")
+        }
 
         // Restore original clipboard
         pasteboard.clearContents()
-        if let strings = savedStrings, !strings.isEmpty {
-            for s in strings {
-                pasteboard.setString(s, forType: .string)
-            }
+        if !savedItems.isEmpty {
+            pasteboard.writeObjects(savedItems.map { $0.makePasteboardItem() })
         }
 
         return grabbed

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,144 +1,99 @@
-# Setting Up Recite in Xcode
+# Setup
 
-All source code is written and ready. ~10 minutes to wire up in Xcode.
+This repo is a Swift Package macOS app. You can build it from Terminal, then use the helper script to assemble and launch a local `.app` bundle.
 
 ## Requirements
-- macOS 14.0+ (Sonoma or later)
-- Xcode with Swift 6.2+
-- Apple Silicon Mac (M1 or later) — required for MLX inference
 
----
+- macOS 14 or newer
+- Apple Silicon Mac
+- Xcode / Swift toolchain
+- Homebrew
+- `espeak-ng`
 
-## Step 1 — Create the Xcode Project
+## First-Time Setup
 
-1. Open Xcode → **File > New > Project**
-2. Select **macOS → App**
-3. Configure:
-   - **Product Name:** `Recite`
-   - **Bundle Identifier:** `com.r3dbars.recite`
-   - **Interface:** `SwiftUI`
-   - **Life Cycle:** `SwiftUI App`
-   - **Language:** `Swift`
-4. Save inside this repo directory
-
----
-
-## Step 2 — Add mlx-audio-swift Package
-
-1. In Xcode: **File → Add Package Dependencies…**
-2. Enter the URL: `https://github.com/r3dbars/mlx-audio-swift.git`
-3. Set dependency rule to **Branch → `codex/recite-tts-manifest-fix`**
-4. Click **Add Package**
-5. In the "Choose Package Products" dialog, add these to your target:
-   - `MLXAudioTTS`
-   - `MLXAudioCore`
-6. Click **Add Package**
-
-> The package will also pull in `mlx-swift` and `swift-numerics` automatically.
-
----
-
-## Step 3 — Replace Generated Files
-
-Delete from Xcode project navigator:
-- `ContentView.swift`
-- `ReciteApp.swift` (the generated one)
-
----
-
-## Step 4 — Add Source Files
-
-Drag all files from `Recite/Sources/Recite/` into the project:
-- `ReciteApp.swift`
-- `AppDelegate.swift`
-- `SpeechEngine.swift`
-- `ReadingQueue.swift`
-- `TextGrabber.swift`
-- `MenuBarView.swift`
-
-Uncheck "Copy items if needed."
-
----
-
-## Step 5 — Info.plist
-
-Add to the **Info** tab of your target:
-
-| Key | Type | Value |
-|-----|------|-------|
-| `NSAppleEventsUsageDescription` | String | Recite needs accessibility access to read selected text from any app. |
-| `NSAccessibilityUsageDescription` | String | Recite needs accessibility access to read selected text from other applications. |
-
-Or replace the generated `Info.plist` with `Recite/Resources/Info.plist`.
-
----
-
-## Step 6 — Signing & Capabilities
-
-1. **Signing & Capabilities** → set your Apple Developer team
-2. Add **Accessibility** capability (or add `Recite.entitlements` from `Recite/Resources/`)
-3. When the app first launches, it will prompt for Accessibility permission in **System Settings → Privacy & Security → Accessibility**
-
----
-
-## Step 7 — Build & Run
-
-Run `./scripts/build-and-run.sh`, or hit **⌘R** from Xcode. Recite opens a main window and also appears in the menu bar.
-
-**First launch:**
-1. The Kokoro 82M model downloads automatically from Hugging Face
-2. You'll see "Loading Model…" while the model initializes
-3. Once loaded, the status changes to "Kokoro TTS Ready"
-4. Grant Accessibility permission when prompted
-
-**Using Recite:**
-1. Select any text in any app
-2. Press **⌃⌥R** — Recite generates speech and reads it aloud
-3. Or click the menu bar icon → **Add Clipboard** to read clipboard text
-4. Use the speed control (0.5x – 2x) to adjust playback speed
-
-> **Note:** First generation takes a few seconds while the model warms up. Subsequent generations are faster.
-
----
-
-## Architecture
-
-```
-ReciteApp.swift      — @main, SwiftUI lifecycle
-AppDelegate.swift    — NSStatusItem, popover, global hotkey (⌃⌥R),
-                       context menu, model loading on launch
-TextGrabber.swift    — Gets selected text via AX API, falls back to ⌘C simulation
-SpeechEngine.swift   — Kokoro 82M via mlx-audio-swift, audio generation + playback
-ReadingQueue.swift   — Queue of text items, auto-advance on completion
-MenuBarView.swift    — SwiftUI popover: player controls, model status, queue, settings
+```bash
+git submodule update --init --recursive
+brew install espeak-ng
+swift build
 ```
 
-**Key design decisions:**
-- Kokoro 82M via mlx-audio-swift — high-quality neural TTS, 100% on-device via MLX
-- Model auto-downloads on first launch from Hugging Face (mlx-community)
-- WAV audio generation → AVAudioPlayer for playback with variable speed
-- Accessibility API first, clipboard simulation fallback
-- Queue + auto-advance — add multiple items, walk away and listen
-- Speed control — 0.5x to 2x playback rate
+The app depends on `local-deps/mlx-audio-swift`, which is tracked as a git submodule.
 
----
+## Run The App
+
+```bash
+./scripts/build-and-run.sh
+```
+
+The script:
+
+1. Runs `swift build`.
+2. Stops any existing `Recite` process.
+3. Assembles `.build/debug/Recite.app`.
+4. Signs it ad-hoc by default.
+5. Opens the app.
+
+If you want to use a real local signing identity, pass it with:
+
+```bash
+RECITE_CODESIGN_IDENTITY="Apple Development: Your Name (TEAMID)" ./scripts/build-and-run.sh
+```
+
+## First Launch
+
+1. Recite asks for Accessibility permission.
+2. The Kokoro 82M model downloads from Hugging Face.
+3. The menu bar status changes to ready when the model is loaded.
+
+Then select text in another app and press **Control + Option + R**.
+
+## Project Map
+
+```text
+Package.swift                 Swift Package entry point
+scripts/build-and-run.sh       Local app bundle builder
+Recite/Sources/Recite/
+  ReciteApp.swift              SwiftUI app entry
+  AppDelegate.swift            Menu bar, hotkey, app lifecycle
+  TextGrabber.swift            Accessibility and clipboard text capture
+  SpeechEngine.swift           Kokoro model loading and audio playback
+  ReadingQueue.swift           Queue and local history
+  MenuBarView.swift            Popover, main window, settings
+Recite/Resources/
+  Info.plist                   App metadata and privacy strings
+  Recite.entitlements          Local development entitlements
+```
 
 ## Troubleshooting
 
-**Model won't load:**
-- Ensure you're on Apple Silicon (M1+). Intel Macs are not supported.
-- Check internet connection — the model downloads from Hugging Face on first launch.
-- Look for errors in the menu bar popover or Xcode console.
+### `mlx-audio-swift/Package.swift` is missing
 
-**No sound:**
-- Check System Settings → Sound → Output device
-- Ensure the app isn't generating (look for "Generating…" indicator)
+Run:
 
-**Hotkey doesn't work:**
-- Grant Accessibility permission: System Settings → Privacy & Security → Accessibility → enable Recite
-- Some apps block AX text reading — clipboard fallback will activate automatically
+```bash
+git submodule update --init --recursive
+```
 
-**Build errors with mlx-audio-swift:**
-- Ensure your Xcode toolchain includes Swift 6.2+
-- Clean build folder: Product → Clean Build Folder (⌘⇧K)
-- Reset package cache: File → Packages → Reset Package Caches
+### Model will not load
+
+- Confirm you are on Apple Silicon.
+- Confirm the first launch has internet access for the model download.
+- Confirm `espeak-ng` is installed with `brew install espeak-ng`.
+
+### Hotkey does not work
+
+Grant Accessibility permission in:
+
+```text
+System Settings -> Privacy & Security -> Accessibility
+```
+
+Then restart Recite.
+
+### Build cache feels stale
+
+```bash
+swift package reset
+swift build
+```

--- a/scripts/build-and-run.sh
+++ b/scripts/build-and-run.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 APP_DIR="$PROJECT_DIR/.build/debug/Recite.app"
 CONTENTS="$APP_DIR/Contents"
-IDENTITY="Apple Development: Justin Betker (LZRN6W4R74)"
+REQUESTED_IDENTITY="${RECITE_CODESIGN_IDENTITY:-}"
 ENTITLEMENTS="$PROJECT_DIR/Recite/Resources/Recite.entitlements"
 RESOURCES="$PROJECT_DIR/Recite/Resources"
 MLX_METAL_SOURCES="$PROJECT_DIR/.build/checkouts/mlx-swift/Source/Cmlx/mlx-generated/metal"
@@ -35,12 +35,16 @@ if [ -d "$MLX_METAL_SOURCES" ]; then
     xcrun -sdk macosx metal -I "$MLX_METAL_SOURCES" -c "$file" -o "$air"
     AIR_FILES+=("$air")
   done < <(find "$MLX_METAL_SOURCES" -name '*.metal' -print0)
-  xcrun -sdk macosx metallib "${AIR_FILES[@]}" -o "$CONTENTS/MacOS/mlx.metallib"
+  if [ "${#AIR_FILES[@]}" -gt 0 ]; then
+    xcrun -sdk macosx metallib "${AIR_FILES[@]}" -o "$CONTENTS/MacOS/mlx.metallib"
+  else
+    echo "==> No MLX Metal kernels found."
+  fi
   rm -rf "$TMP_METAL_DIR"
 fi
 
-if security find-identity -v -p codesigning | grep -q "$IDENTITY"; then
-  SIGN_IDENTITY="$IDENTITY"
+if [ -n "$REQUESTED_IDENTITY" ] && security find-identity -v -p codesigning | grep -Fq "$REQUESTED_IDENTITY"; then
+  SIGN_IDENTITY="$REQUESTED_IDENTITY"
 else
   SIGN_IDENTITY="-"
 fi


### PR DESCRIPTION
## Summary

- Add public-friendly README, setup, contributor, and agent notes.
- Add `.mailmap` so older Justin author aliases show as `r3dbars` while Claude and Josh stay separate.
- Remove the hard-coded personal signing identity from the local build script.
- Tighten privacy-sensitive logging and clipboard restoration around selected text capture.
- Add small app cleanup around espeak-ng detection, speed persistence, and playback safety.

## Validation

- `swift build`
- `swift test` (builds, then reports no test targets yet)
- `bash -n scripts/build-and-run.sh`
- `plutil -lint Recite/Resources/Info.plist Recite/Resources/Recite.entitlements`
- `git log --use-mailmap --format='%aN <%aE>' --all | sort | uniq -c | sort -nr`
