### PR TITLE
[codex] Add buffered TTS streaming and voice previews

### DIFF
--- a/Recite/Sources/Recite/MenuBarView.swift
+++ b/Recite/Sources/Recite/MenuBarView.swift
@@ -1189,30 +1189,46 @@ struct SettingsDetailView: View {
                 GroupBox {
                     VStack(alignment: .leading, spacing: 2) {
                         ForEach(SpeechEngine.voicePresets) { preset in
-                            Button {
-                                engine.selectedVoice = preset.kokoroVoice
-                            } label: {
-                                HStack(spacing: 10) {
-                                    Image(systemName: engine.selectedVoice == preset.kokoroVoice
-                                          ? "checkmark.circle.fill" : "circle")
-                                        .foregroundColor(engine.selectedVoice == preset.kokoroVoice
-                                                         ? .accentColor : Color(NSColor.quaternaryLabelColor))
-                                        .font(.system(size: 14))
+                            HStack(spacing: 10) {
+                                Button {
+                                    engine.selectedVoice = preset.kokoroVoice
+                                } label: {
+                                    HStack(spacing: 10) {
+                                        Image(systemName: engine.selectedVoice == preset.kokoroVoice
+                                              ? "checkmark.circle.fill" : "circle")
+                                            .foregroundColor(engine.selectedVoice == preset.kokoroVoice
+                                                             ? .accentColor : Color(NSColor.quaternaryLabelColor))
+                                            .font(.system(size: 14))
 
-                                    Text(preset.name)
-                                        .font(.system(size: 13))
-                                        .foregroundColor(.primary)
+                                        Text(preset.name)
+                                            .font(.system(size: 13))
+                                            .foregroundColor(.primary)
 
-                                    Text(preset.kokoroVoice)
-                                        .font(.system(size: 11))
-                                        .foregroundColor(.secondary)
+                                        Text(preset.kokoroVoice)
+                                            .font(.system(size: 11))
+                                            .foregroundColor(.secondary)
 
-                                    Spacer()
+                                        Spacer()
+                                    }
+                                    .contentShape(Rectangle())
                                 }
-                                .padding(.vertical, 5)
-                                .contentShape(Rectangle())
+                                .buttonStyle(.plain)
+
+                                Button {
+                                    engine.previewVoice(preset)
+                                } label: {
+                                    Image(systemName: engine.previewingVoice == preset.kokoroVoice
+                                          ? "stop.fill" : "play.fill")
+                                        .font(.system(size: 10, weight: .semibold))
+                                        .frame(width: 22, height: 22)
+                                }
+                                .buttonStyle(.borderless)
+                                .disabled(engine.modelStatus != .ready || engine.state != .idle)
+                                .help(engine.previewingVoice == preset.kokoroVoice
+                                      ? "Stop preview"
+                                      : "Preview \(preset.name)")
                             }
-                            .buttonStyle(.plain)
+                            .padding(.vertical, 5)
 
                             if preset.id != SpeechEngine.voicePresets.last?.id {
                                 Divider()

--- a/Recite/Sources/Recite/MenuBarView.swift
+++ b/Recite/Sources/Recite/MenuBarView.swift
@@ -1162,122 +1162,226 @@ struct SettingsDetailView: View {
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 28) {
-
-                // Speed
-                GroupBox {
-                    VStack(alignment: .leading, spacing: 10) {
-                        HStack {
-                            Text("0.5×").font(.system(size: 11)).foregroundColor(.secondary)
-                            Slider(
-                                value: Binding(get: { engine.speed }, set: { engine.updateSpeed($0) }),
-                                in: 0.5...2.0, step: 0.25
-                            )
-                            Text("2×").font(.system(size: 11)).foregroundColor(.secondary)
-                        }
-                        Text("Current speed: \(speedLabel(engine.speed))")
-                            .font(.system(size: 11))
-                            .foregroundColor(.secondary)
-                    }
-                    .padding(.top, 4)
-                } label: {
-                    Label("Playback Speed", systemImage: "speedometer")
-                        .font(.system(size: 13, weight: .semibold))
+            VStack(alignment: .leading, spacing: 18) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Settings")
+                        .font(.system(size: 30, weight: .bold))
+                    Text("Voice, speed, and local model")
+                        .font(.system(size: 13))
+                        .foregroundColor(.secondary)
                 }
+                .padding(.bottom, 4)
 
-                // Voice
-                GroupBox {
-                    VStack(alignment: .leading, spacing: 2) {
-                        ForEach(SpeechEngine.voicePresets) { preset in
+                SettingsPanel {
+                    HStack(alignment: .center, spacing: 18) {
+                        ZStack {
+                            Circle()
+                                .fill(Color.accentColor.opacity(0.16))
+                            Image(systemName: "speedometer")
+                                .font(.system(size: 20, weight: .semibold))
+                                .foregroundColor(.accentColor)
+                        }
+                        .frame(width: 46, height: 46)
+
+                        VStack(alignment: .leading, spacing: 10) {
+                            HStack(alignment: .firstTextBaseline) {
+                                Text("Playback Speed")
+                                    .font(.system(size: 16, weight: .semibold))
+                                Spacer()
+                                Text(speedLabel(engine.speed))
+                                    .font(.system(size: 18, weight: .bold, design: .rounded))
+                                    .foregroundColor(.accentColor)
+                            }
+
                             HStack(spacing: 10) {
-                                Button {
-                                    engine.selectedVoice = preset.kokoroVoice
-                                } label: {
-                                    HStack(spacing: 10) {
-                                        Image(systemName: engine.selectedVoice == preset.kokoroVoice
-                                              ? "checkmark.circle.fill" : "circle")
-                                            .foregroundColor(engine.selectedVoice == preset.kokoroVoice
-                                                             ? .accentColor : Color(NSColor.quaternaryLabelColor))
-                                            .font(.system(size: 14))
-
-                                        Text(preset.name)
-                                            .font(.system(size: 13))
-                                            .foregroundColor(.primary)
-
-                                        Text(preset.kokoroVoice)
-                                            .font(.system(size: 11))
-                                            .foregroundColor(.secondary)
-
-                                        Spacer()
-                                    }
-                                    .contentShape(Rectangle())
-                                }
-                                .buttonStyle(.plain)
-
-                                Button {
-                                    engine.previewVoice(preset)
-                                } label: {
-                                    Image(systemName: engine.previewingVoice == preset.kokoroVoice
-                                          ? "stop.fill" : "play.fill")
-                                        .font(.system(size: 10, weight: .semibold))
-                                        .frame(width: 22, height: 22)
-                                }
-                                .buttonStyle(.borderless)
-                                .disabled(engine.modelStatus != .ready || engine.state != .idle)
-                                .help(engine.previewingVoice == preset.kokoroVoice
-                                      ? "Stop preview"
-                                      : "Preview \(preset.name)")
-                            }
-                            .padding(.vertical, 5)
-
-                            if preset.id != SpeechEngine.voicePresets.last?.id {
-                                Divider()
+                                Text("0.5×")
+                                    .font(.system(size: 11, weight: .medium))
+                                    .foregroundColor(.secondary)
+                                Slider(
+                                    value: Binding(get: { engine.speed }, set: { engine.updateSpeed($0) }),
+                                    in: 0.5...2.0, step: 0.25
+                                )
+                                Text("2×")
+                                    .font(.system(size: 11, weight: .medium))
+                                    .foregroundColor(.secondary)
                             }
                         }
                     }
-                    .padding(.top, 4)
-                } label: {
-                    Label("Voice", systemImage: "mic")
-                        .font(.system(size: 13, weight: .semibold))
                 }
 
-                // Model info
-                GroupBox {
+                SettingsPanel {
                     HStack {
-                        Label("Kokoro 82M (bf16)", systemImage: "brain")
-                            .font(.system(size: 13))
+                        Label("Kokoro 82M", systemImage: "brain")
+                            .font(.system(size: 13, weight: .semibold))
+                        Text("bf16")
+                            .font(.system(size: 11, weight: .semibold))
+                            .foregroundColor(.secondary)
+                            .padding(.horizontal, 7)
+                            .padding(.vertical, 3)
+                            .background(Color(NSColor.controlBackgroundColor))
+                            .clipShape(Capsule())
                         Spacer()
-                        switch engine.modelStatus {
-                        case .ready:
-                            Label("Ready", systemImage: "checkmark.circle.fill")
-                                .font(.system(size: 12))
-                                .foregroundColor(.green)
-                        case .error:
-                            Button("Retry") { Task { await engine.loadModel() } }
-                                .font(.system(size: 12))
-                        default:
-                            ProgressView().controlSize(.small)
-                        }
+                        modelStatusView
                     }
-                    .padding(.vertical, 4)
-                } label: {
-                    Label("Model", systemImage: "cpu")
-                        .font(.system(size: 13, weight: .semibold))
                 }
 
-                Text("100% on-device  ·  Apple Silicon  ·  MIT License")
-                    .font(.system(size: 11))
-                    .foregroundColor(Color(NSColor.tertiaryLabelColor))
+                VStack(alignment: .leading, spacing: 10) {
+                    HStack {
+                        Label("Voices", systemImage: "mic")
+                            .font(.system(size: 16, weight: .semibold))
+                        Spacer()
+                        if engine.previewingVoice != nil {
+                            Button {
+                                engine.stopVoicePreview()
+                            } label: {
+                                Label("Stop", systemImage: "stop.fill")
+                            }
+                            .controlSize(.small)
+                        }
+                    }
+
+                    VStack(spacing: 8) {
+                        ForEach(SpeechEngine.voicePresets) { preset in
+                            VoiceChoiceRow(
+                                preset: preset,
+                                isSelected: engine.selectedVoice == preset.kokoroVoice,
+                                isPreviewing: engine.previewingVoice == preset.kokoroVoice,
+                                canPreview: engine.modelStatus == .ready && engine.state == .idle,
+                                select: { engine.selectedVoice = preset.kokoroVoice },
+                                preview: { engine.previewVoice(preset) }
+                            )
+                        }
+                    }
+                }
             }
-            .padding(24)
+            .padding(28)
+            .frame(maxWidth: 920, alignment: .leading)
         }
-        .navigationTitle("Settings")
+        .navigationTitle("")
+    }
+
+    @ViewBuilder
+    private var modelStatusView: some View {
+        switch engine.modelStatus {
+        case .ready:
+            StatusPill(title: "Ready", systemImage: "checkmark.circle.fill", color: .green)
+        case .error:
+            Button("Retry") { Task { await engine.loadModel() } }
+                .controlSize(.small)
+        case .downloading(let p):
+            StatusPill(title: "Downloading \(Int(p * 100))%", systemImage: "arrow.down.circle.fill", color: .blue)
+        case .loading:
+            HStack(spacing: 6) {
+                ProgressView().controlSize(.small)
+                Text("Loading")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(.secondary)
+            }
+        case .notLoaded:
+            StatusPill(title: "Not Loaded", systemImage: "exclamationmark.circle.fill", color: .orange)
+        }
     }
 
     private func speedLabel(_ rate: Double) -> String {
         if rate == 1.0 { return "1×" }
         if rate == floor(rate) { return "\(Int(rate))×" }
         return String(format: "%.2g×", rate)
+    }
+}
+
+private struct SettingsPanel<Content: View>: View {
+    @ViewBuilder var content: Content
+
+    var body: some View {
+        content
+            .padding(16)
+            .background(Color(NSColor.controlBackgroundColor))
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(Color(NSColor.separatorColor), lineWidth: 0.5)
+            )
+    }
+}
+
+private struct VoiceChoiceRow: View {
+    let preset: VoicePreset
+    let isSelected: Bool
+    let isPreviewing: Bool
+    let canPreview: Bool
+    let select: () -> Void
+    let preview: () -> Void
+
+    var body: some View {
+        HStack(spacing: 14) {
+            Button(action: select) {
+                HStack(spacing: 12) {
+                    Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                        .font(.system(size: 17, weight: .medium))
+                        .foregroundColor(isSelected ? .accentColor : Color(NSColor.quaternaryLabelColor))
+                        .frame(width: 20)
+
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text(preset.name)
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundColor(.primary)
+                        Text(voiceDescription)
+                            .font(.system(size: 11))
+                            .foregroundColor(.secondary)
+                    }
+
+                    Spacer()
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            Button(action: preview) {
+                Label(isPreviewing ? "Stop" : "Preview",
+                      systemImage: isPreviewing ? "stop.fill" : "play.fill")
+                    .font(.system(size: 12, weight: .semibold))
+                    .frame(width: 84)
+            }
+            .controlSize(.small)
+            .disabled(!canPreview && !isPreviewing)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
+        .background(rowBackground)
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(isSelected ? Color.accentColor.opacity(0.45) : Color(NSColor.separatorColor), lineWidth: 0.7)
+        )
+    }
+
+    private var rowBackground: Color {
+        if isSelected { return Color.accentColor.opacity(0.1) }
+        return Color(NSColor.controlBackgroundColor)
+    }
+
+    private var voiceDescription: String {
+        let locale = preset.kokoroVoice.hasPrefix("b") ? "British" : "American"
+        let tone = preset.kokoroVoice.hasPrefix("a") || preset.kokoroVoice.hasPrefix("b")
+            ? "English"
+            : "Voice"
+        return "\(locale) \(tone) · \(preset.kokoroVoice)"
+    }
+}
+
+private struct StatusPill: View {
+    let title: String
+    let systemImage: String
+    let color: Color
+
+    var body: some View {
+        Label(title, systemImage: systemImage)
+            .font(.system(size: 12, weight: .semibold))
+            .foregroundColor(color)
+            .padding(.horizontal, 9)
+            .padding(.vertical, 5)
+            .background(color.opacity(0.12))
+            .clipShape(Capsule())
     }
 }
 

--- a/Recite/Sources/Recite/SpeechEngine.swift
+++ b/Recite/Sources/Recite/SpeechEngine.swift
@@ -201,7 +201,7 @@ class SpeechEngine: NSObject, ObservableObject {
         previewTask = Task {
             do {
                 let params = GenerateParameters()
-                let sampleText = "Hello from \(preset.name). Recite can read articles, emails, and notes out loud."
+                let sampleText = "Hello from \(preset.name), Recite can read articles, emails, and notes out loud"
                 let audio = try await model.generate(
                     text: sampleText,
                     voice: preset.kokoroVoice,

--- a/Recite/Sources/Recite/SpeechEngine.swift
+++ b/Recite/Sources/Recite/SpeechEngine.swift
@@ -63,6 +63,7 @@ class SpeechEngine: NSObject, ObservableObject {
     @Published var currentText: String = ""
     @Published var progress: Double = 0
     @Published var speed: Double = 1.0  // 0.5x – 2.0x playback speed
+    @Published var previewingVoice: String?
     @Published var selectedVoice: String = UserDefaults.standard.string(forKey: "selectedVoice")
         ?? VoicePreset.defaultPreset.kokoroVoice {
         didSet {
@@ -109,6 +110,9 @@ class SpeechEngine: NSObject, ObservableObject {
     private var streamingGenerationComplete = false
     private var streamingPlaybackStarted = false
     private var progressTask: Task<Void, Never>?
+    private var previewTask: Task<Void, Never>?
+    private var previewAudioEngine: AVAudioEngine?
+    private var previewPlayerNode: AVAudioPlayerNode?
 
     private static let modelID = "mlx-community/Kokoro-82M-bf16"
     private static let sampleRate: Double = 24000
@@ -178,6 +182,97 @@ class SpeechEngine: NSObject, ObservableObject {
         return false
     }
 
+    // MARK: - Voice Preview
+
+    func previewVoice(_ preset: VoicePreset) {
+        if previewingVoice == preset.kokoroVoice {
+            stopVoicePreview()
+            return
+        }
+
+        guard modelStatus == .ready, let model else {
+            log.warning("previewVoice() called but model not ready")
+            return
+        }
+
+        stopVoicePreview()
+        previewingVoice = preset.kokoroVoice
+
+        previewTask = Task {
+            do {
+                let params = GenerateParameters()
+                let sampleText = "Hi, I'm \(preset.name). This is how I sound reading with Recite."
+                let audio = try await model.generate(
+                    text: sampleText,
+                    voice: preset.kokoroVoice,
+                    refAudio: nil,
+                    refText: nil,
+                    language: "en-us",
+                    generationParameters: params
+                )
+                if Task.isCancelled { return }
+                let samples = audio.asArray(Float.self)
+                await MainActor.run {
+                    guard self.previewingVoice == preset.kokoroVoice else { return }
+                    self.playVoicePreview(samples, voiceID: preset.kokoroVoice)
+                }
+            } catch {
+                log.error("Voice preview failed: \(error.localizedDescription)")
+                await MainActor.run {
+                    guard self.previewingVoice == preset.kokoroVoice else { return }
+                    self.stopVoicePreview()
+                }
+            }
+        }
+    }
+
+    func stopVoicePreview() {
+        previewTask?.cancel()
+        previewTask = nil
+        previewPlayerNode?.stop()
+        previewAudioEngine?.stop()
+        previewPlayerNode = nil
+        previewAudioEngine = nil
+        previewingVoice = nil
+    }
+
+    private func playVoicePreview(_ samples: [Float], voiceID: String) {
+        let engine = AVAudioEngine()
+        let player = AVAudioPlayerNode()
+        let format = AVAudioFormat(standardFormatWithSampleRate: Self.sampleRate, channels: 1)!
+
+        engine.attach(player)
+        engine.connect(player, to: engine.mainMixerNode, format: format)
+
+        let frameCount = AVAudioFrameCount(samples.count)
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount) else {
+            stopVoicePreview()
+            return
+        }
+        buffer.frameLength = frameCount
+        let channelData = buffer.floatChannelData![0]
+        for i in 0..<samples.count {
+            channelData[i] = max(-1.0, min(1.0, samples[i]))
+        }
+
+        do {
+            try engine.start()
+            previewAudioEngine = engine
+            previewPlayerNode = player
+            player.scheduleBuffer(buffer) { [weak self] in
+                Task { @MainActor in
+                    guard let self, self.previewingVoice == voiceID else { return }
+                    self.stopVoicePreview()
+                }
+            }
+            player.play()
+            log.info("Voice preview started for \(voiceID)")
+        } catch {
+            log.error("Voice preview audio failed: \(error.localizedDescription)")
+            stopVoicePreview()
+        }
+    }
+
     // MARK: - Playback
 
     func speak(_ text: String) {
@@ -189,6 +284,7 @@ class SpeechEngine: NSObject, ObservableObject {
         log.info("speak() called with \(text.count) chars")
 
         // Cancel any in-progress generation
+        stopVoicePreview()
         generationTask?.cancel()
         stopAudioEngine()
 
@@ -625,6 +721,7 @@ class SpeechEngine: NSObject, ObservableObject {
     }
 
     func stop() {
+        stopVoicePreview()
         generationID &+= 1
         generationTask?.cancel()
         stopAudioEngine()

--- a/Recite/Sources/Recite/SpeechEngine.swift
+++ b/Recite/Sources/Recite/SpeechEngine.swift
@@ -201,7 +201,7 @@ class SpeechEngine: NSObject, ObservableObject {
         previewTask = Task {
             do {
                 let params = GenerateParameters()
-                let sampleText = "Hi, I'm \(preset.name), this is how I sound reading with Recite."
+                let sampleText = "Hi, I'm \(preset.name). This is how I sound reading with Recite."
                 let audio = try await model.generate(
                     text: sampleText,
                     voice: preset.kokoroVoice,

--- a/Recite/Sources/Recite/SpeechEngine.swift
+++ b/Recite/Sources/Recite/SpeechEngine.swift
@@ -201,7 +201,7 @@ class SpeechEngine: NSObject, ObservableObject {
         previewTask = Task {
             do {
                 let params = GenerateParameters()
-                let sampleText = "Hi, I'm \(preset.name). This is how I sound reading with Recite."
+                let sampleText = "Hi, I'm \(preset.name) -- This is how I sound reading with Recite."
                 let audio = try await model.generate(
                     text: sampleText,
                     voice: preset.kokoroVoice,

--- a/Recite/Sources/Recite/SpeechEngine.swift
+++ b/Recite/Sources/Recite/SpeechEngine.swift
@@ -104,9 +104,18 @@ class SpeechEngine: NSObject, ObservableObject {
     private var timePitchNode: AVAudioUnitTimePitch?
     private var audioFormat: AVAudioFormat?
     private var totalSamplesScheduled = 0
+    private var playbackChunksScheduled = 0
+    private var playbackChunksCompleted = 0
+    private var streamingGenerationComplete = false
+    private var streamingPlaybackStarted = false
+    private var progressTask: Task<Void, Never>?
 
     private static let modelID = "mlx-community/Kokoro-82M-bf16"
     private static let sampleRate: Double = 24000
+    private static let fastEnoughMargin = 1.15
+    private static let minimumStartupBufferSeconds = 1.25
+    private static let comfortableStartupBufferSeconds = 3.0
+    private static let lowWaterWallSeconds = 2.5
 
     override init() {
         super.init()
@@ -208,8 +217,22 @@ class SpeechEngine: NSObject, ObservableObject {
                     return
                 }
 
-                var allSamples: [Float] = []
-                let startTime = CFAbsoluteTimeGetCurrent()
+                let generationStartTime = CFAbsoluteTimeGetCurrent()
+                let totalTextChars = sentences.reduce(0) { $0 + $1.count }
+                var generatedAudioSeconds = 0.0
+                var generatedTextChars = 0
+                var playbackHasStarted = false
+                await MainActor.run {
+                    guard self.generationID == myGenID else { return }
+                    self.setupAudioEngine()
+                    self.startProgressTracker(totalEstimatedAudioSeconds: {
+                        let textRatio = totalTextChars > 0
+                            ? Double(generatedTextChars) / Double(totalTextChars)
+                            : 1.0
+                        guard textRatio > 0 else { return generatedAudioSeconds }
+                        return max(generatedAudioSeconds / textRatio, generatedAudioSeconds)
+                    })
+                }
 
                 for (i, sentence) in sentences.enumerated() {
                     if Task.isCancelled { return }
@@ -230,35 +253,53 @@ class SpeechEngine: NSObject, ObservableObject {
                     )
 
                     let samples = audio.asArray(Float.self)
-                    log.info("Sentence \(i+1): \(samples.count) samples (\(Double(samples.count) / Self.sampleRate)s)")
-                    allSamples.append(contentsOf: samples)
+                    let chunkAudioSeconds = Double(samples.count) / Self.sampleRate
+                    generatedAudioSeconds += chunkAudioSeconds
+                    generatedTextChars += trimmed.count
+
+                    let elapsed = max(CFAbsoluteTimeGetCurrent() - generationStartTime, 0.001)
+                    let generationRate = generatedAudioSeconds / elapsed
+                    let estimatedTotalAudioSeconds = estimateTotalAudioSeconds(
+                        generatedAudioSeconds: generatedAudioSeconds,
+                        generatedTextChars: generatedTextChars,
+                        totalTextChars: totalTextChars
+                    )
+                    let estimatedRemainingAudioSeconds = max(estimatedTotalAudioSeconds - generatedAudioSeconds, 0)
+                    let startupTarget = startupBufferTargetSeconds(
+                        generationRate: generationRate,
+                        playbackRate: self.speed,
+                        estimatedRemainingAudioSeconds: estimatedRemainingAudioSeconds
+                    )
+                    let shouldStartPlayback = generatedAudioSeconds >= startupTarget || i == sentences.count - 1
+
+                    log.info("Sentence \(i+1): \(samples.count) samples (\(String(format: "%.2f", chunkAudioSeconds))s), generation \(String(format: "%.2f", generationRate))x audio-time, startup target \(String(format: "%.2f", startupTarget))s")
 
                     await MainActor.run {
                         guard self.generationID == myGenID else { return }
-                        self.progress = Double(i + 1) / Double(sentences.count) * 0.5
+                        self.scheduleStreamingAudio(samples, isFinalChunk: false)
+                        self.progress = min(Double(i + 1) / Double(sentences.count), 0.98)
+
+                        guard shouldStartPlayback, !playbackHasStarted else { return }
+                        playbackHasStarted = true
+                        self.streamingPlaybackStarted = true
+                        self.playerNode?.play()
+                        self.state = .playing
+                        log.info("Streaming playback started after buffering \(String(format: "%.2f", generatedAudioSeconds))s audio; generation rate \(String(format: "%.2f", generationRate))x, playback rate \(String(format: "%.2f", self.speed))x")
                     }
                 }
 
                 if Task.isCancelled { return }
 
-                guard !allSamples.isEmpty else {
-                    await MainActor.run {
-                        guard self.generationID == myGenID else { return }
-                        self.state = .idle
-                        self.currentText = ""
-                        self.progress = 0
-                    }
-                    return
-                }
-
-                let elapsed = CFAbsoluteTimeGetCurrent() - startTime
-                let audioDuration = Double(allSamples.count) / Self.sampleRate
-                let rtf = audioDuration / elapsed
-                log.info("Generation complete: \(allSamples.count) samples, \(String(format: "%.1f", audioDuration))s audio in \(String(format: "%.1f", elapsed))s (\(String(format: "%.1f", rtf))x real-time)")
-
                 await MainActor.run {
                     guard self.generationID == myGenID else { return }
-                    self.playAudio(allSamples)
+                    self.streamingGenerationComplete = true
+                    if !playbackHasStarted {
+                        playbackHasStarted = true
+                        self.streamingPlaybackStarted = true
+                        self.playerNode?.play()
+                        self.state = .playing
+                    }
+                    self.finishPlaybackIfComplete()
                 }
 
             } catch {
@@ -272,6 +313,44 @@ class SpeechEngine: NSObject, ObservableObject {
                 }
             }
         }
+    }
+
+    private func estimateTotalAudioSeconds(
+        generatedAudioSeconds: Double,
+        generatedTextChars: Int,
+        totalTextChars: Int
+    ) -> Double {
+        guard generatedAudioSeconds > 0, generatedTextChars > 0, totalTextChars > 0 else {
+            return generatedAudioSeconds
+        }
+        let audioSecondsPerChar = generatedAudioSeconds / Double(generatedTextChars)
+        return audioSecondsPerChar * Double(totalTextChars)
+    }
+
+    /// Pick the startup buffer that avoids underruns.
+    /// If generation is faster than playback, start quickly. If it is slower, wait
+    /// long enough that the estimated buffer drain is covered before playback begins.
+    private func startupBufferTargetSeconds(
+        generationRate: Double,
+        playbackRate: Double,
+        estimatedRemainingAudioSeconds: Double
+    ) -> Double {
+        let playbackRate = max(playbackRate, 0.1)
+        let lowWaterAudioSeconds = Self.lowWaterWallSeconds * playbackRate
+        guard generationRate > 0 else {
+            return max(lowWaterAudioSeconds, Self.comfortableStartupBufferSeconds)
+        }
+
+        if generationRate >= playbackRate * Self.fastEnoughMargin {
+            return Self.minimumStartupBufferSeconds * playbackRate
+        }
+
+        if generationRate >= playbackRate {
+            return max(lowWaterAudioSeconds, Self.comfortableStartupBufferSeconds * playbackRate)
+        }
+
+        let expectedDrain = ((playbackRate - generationRate) / generationRate) * estimatedRemainingAudioSeconds
+        return max(lowWaterAudioSeconds + expectedDrain, Self.comfortableStartupBufferSeconds * playbackRate)
     }
 
     /// Clean raw text before TTS — strips Slack noise, timestamps, emoji codes, file attachments.
@@ -396,8 +475,7 @@ class SpeechEngine: NSObject, ObservableObject {
         return chunks
     }
 
-    private func playAudio(_ samples: [Float]) {
-        setupAudioEngine()
+    private func scheduleStreamingAudio(_ samples: [Float], isFinalChunk: Bool) {
         guard let player = playerNode, let format = audioFormat else { return }
 
         let frameCount = AVAudioFrameCount(samples.count)
@@ -409,35 +487,34 @@ class SpeechEngine: NSObject, ObservableObject {
             channelData[i] = max(-1.0, min(1.0, samples[i]))
         }
 
-        totalSamplesScheduled = samples.count
+        totalSamplesScheduled += samples.count
+        playbackChunksScheduled += 1
         let expectedGenID = self.generationID
 
         player.scheduleBuffer(buffer) { [weak self] in
             Task { @MainActor in
                 guard let self else { return }
                 guard self.generationID == expectedGenID else { return }
-                self.finishPlayback()
-            }
-        }
-
-        player.play()
-        state = .playing
-        log.info("Playback started (\(samples.count) samples, \(String(format: "%.1f", Double(samples.count) / Self.sampleRate))s)")
-
-        // Track progress
-        Task {
-            while state == .playing || state == .paused {
-                if let player = playerNode, let nodeTime = player.lastRenderTime,
-                   let playerTime = player.playerTime(forNodeTime: nodeTime),
-                   totalSamplesScheduled > 0 {
-                    let currentSample = Double(playerTime.sampleTime)
-                    let total = Double(totalSamplesScheduled)
-                    // Map playback progress to 0.5–1.0 (first 0.5 was generation)
-                    progress = 0.5 + min(currentSample / total, 1.0) * 0.5
+                self.playbackChunksCompleted += 1
+                if !self.streamingGenerationComplete,
+                   self.streamingPlaybackStarted,
+                   self.playbackChunksCompleted >= self.playbackChunksScheduled {
+                    self.state = .generating
+                    log.info("Playback buffer drained before generation finished; waiting for the next chunk")
                 }
-                try? await Task.sleep(nanoseconds: 200_000_000) // 200ms
+                self.finishPlaybackIfComplete()
             }
         }
+        streamingGenerationComplete = streamingGenerationComplete || isFinalChunk
+        if streamingPlaybackStarted,
+           state != .paused,
+           !player.isPlaying,
+           bufferedAudioSeconds() >= resumeBufferTargetSeconds() {
+            player.play()
+            state = .playing
+            log.info("Playback resumed with \(String(format: "%.2f", self.bufferedAudioSeconds()))s buffered")
+        }
+        log.info("Scheduled streaming chunk \(self.playbackChunksScheduled): \(String(format: "%.2f", Double(samples.count) / Self.sampleRate))s audio")
     }
 
     private func setupAudioEngine() {
@@ -458,13 +535,60 @@ class SpeechEngine: NSObject, ObservableObject {
             self.playerNode = player
             self.timePitchNode = timePitch
             self.audioFormat = format
+            self.totalSamplesScheduled = 0
+            self.playbackChunksScheduled = 0
+            self.playbackChunksCompleted = 0
+            self.streamingGenerationComplete = false
+            self.streamingPlaybackStarted = false
             log.info("Audio engine started (speed: \(self.speed)x)")
         } catch {
             log.error("Failed to start audio engine: \(error.localizedDescription)")
         }
     }
 
+    private func startProgressTracker(totalEstimatedAudioSeconds: @escaping @MainActor () -> Double) {
+        progressTask?.cancel()
+        progressTask = Task { @MainActor in
+            while !Task.isCancelled && (state == .generating || state == .playing || state == .paused) {
+                let playedSeconds = currentPlaybackSourceSeconds()
+                let totalSeconds = max(totalEstimatedAudioSeconds(), Double(totalSamplesScheduled) / Self.sampleRate)
+                if totalSeconds > 0 {
+                    progress = min(playedSeconds / totalSeconds, 0.99)
+                }
+                try? await Task.sleep(nanoseconds: 200_000_000)
+            }
+        }
+    }
+
+    private func currentPlaybackSourceSeconds() -> Double {
+        guard let player = playerNode,
+              let nodeTime = player.lastRenderTime,
+              let playerTime = player.playerTime(forNodeTime: nodeTime) else {
+            return 0
+        }
+        return max(Double(playerTime.sampleTime) / Self.sampleRate, 0)
+    }
+
+    private func bufferedAudioSeconds() -> Double {
+        max(Double(totalSamplesScheduled) / Self.sampleRate - currentPlaybackSourceSeconds(), 0)
+    }
+
+    private func resumeBufferTargetSeconds() -> Double {
+        max(Self.minimumStartupBufferSeconds * speed, 0.5)
+    }
+
+    private func finishPlaybackIfComplete() {
+        guard streamingGenerationComplete,
+              playbackChunksScheduled > 0,
+              playbackChunksCompleted >= playbackChunksScheduled else {
+            return
+        }
+        finishPlayback()
+    }
+
     private func finishPlayback() {
+        progressTask?.cancel()
+        progressTask = nil
         progress = 1.0
         state = .idle
         currentText = ""
@@ -473,6 +597,8 @@ class SpeechEngine: NSObject, ObservableObject {
     }
 
     private func stopAudioEngine() {
+        progressTask?.cancel()
+        progressTask = nil
         playerNode?.stop()
         audioEngine?.stop()
         audioEngine = nil
@@ -480,6 +606,10 @@ class SpeechEngine: NSObject, ObservableObject {
         timePitchNode = nil
         audioFormat = nil
         totalSamplesScheduled = 0
+        playbackChunksScheduled = 0
+        playbackChunksCompleted = 0
+        streamingGenerationComplete = false
+        streamingPlaybackStarted = false
     }
 
     func pause() {

--- a/Recite/Sources/Recite/SpeechEngine.swift
+++ b/Recite/Sources/Recite/SpeechEngine.swift
@@ -201,7 +201,7 @@ class SpeechEngine: NSObject, ObservableObject {
         previewTask = Task {
             do {
                 let params = GenerateParameters()
-                let sampleText = "Hi, I'm \(preset.name) -- This is how I sound reading with Recite."
+                let sampleText = "Hello from \(preset.name). Recite can read articles, emails, and notes out loud."
                 let audio = try await model.generate(
                     text: sampleText,
                     voice: preset.kokoroVoice,

--- a/Recite/Sources/Recite/SpeechEngine.swift
+++ b/Recite/Sources/Recite/SpeechEngine.swift
@@ -201,7 +201,7 @@ class SpeechEngine: NSObject, ObservableObject {
         previewTask = Task {
             do {
                 let params = GenerateParameters()
-                let sampleText = "Hi, I'm \(preset.name). This is how I sound reading with Recite."
+                let sampleText = "Hi, I'm \(preset.name), this is how I sound reading with Recite."
                 let audio = try await model.generate(
                     text: sampleText,
                     voice: preset.kokoroVoice,

--- a/Recite/Sources/Recite/SpeechEngine.swift
+++ b/Recite/Sources/Recite/SpeechEngine.swift
@@ -272,7 +272,7 @@ class SpeechEngine: NSObject, ObservableObject {
                     )
                     let shouldStartPlayback = generatedAudioSeconds >= startupTarget || i == sentences.count - 1
 
-                    log.info("Sentence \(i+1): \(samples.count) samples (\(String(format: "%.2f", chunkAudioSeconds))s), generation \(String(format: "%.2f", generationRate))x audio-time, startup target \(String(format: "%.2f", startupTarget))s")
+                    log.info("Sentence \(i+1, privacy: .public): \(samples.count, privacy: .public) samples (\(String(format: "%.2f", chunkAudioSeconds), privacy: .public)s), generation \(String(format: "%.2f", generationRate), privacy: .public)x audio-time, startup target \(String(format: "%.2f", startupTarget), privacy: .public)s")
 
                     await MainActor.run {
                         guard self.generationID == myGenID else { return }
@@ -284,7 +284,7 @@ class SpeechEngine: NSObject, ObservableObject {
                         self.streamingPlaybackStarted = true
                         self.playerNode?.play()
                         self.state = .playing
-                        log.info("Streaming playback started after buffering \(String(format: "%.2f", generatedAudioSeconds))s audio; generation rate \(String(format: "%.2f", generationRate))x, playback rate \(String(format: "%.2f", self.speed))x")
+                        log.info("Streaming playback started after buffering \(String(format: "%.2f", generatedAudioSeconds), privacy: .public)s audio; generation rate \(String(format: "%.2f", generationRate), privacy: .public)x, playback rate \(String(format: "%.2f", self.speed), privacy: .public)x")
                     }
                 }
 
@@ -512,9 +512,9 @@ class SpeechEngine: NSObject, ObservableObject {
            bufferedAudioSeconds() >= resumeBufferTargetSeconds() {
             player.play()
             state = .playing
-            log.info("Playback resumed with \(String(format: "%.2f", self.bufferedAudioSeconds()))s buffered")
+            log.info("Playback resumed with \(String(format: "%.2f", self.bufferedAudioSeconds()), privacy: .public)s buffered")
         }
-        log.info("Scheduled streaming chunk \(self.playbackChunksScheduled): \(String(format: "%.2f", Double(samples.count) / Self.sampleRate))s audio")
+        log.info("Scheduled streaming chunk \(self.playbackChunksScheduled, privacy: .public): \(String(format: "%.2f", Double(samples.count) / Self.sampleRate), privacy: .public)s audio")
     }
 
     private func setupAudioEngine() {


### PR DESCRIPTION
## Summary

- stream generated TTS chunks into playback with adaptive startup buffering instead of waiting for the full selection to generate
- add per-voice preview playback and a clearer settings voice picker
- expose useful streaming timing logs for local performance checks

## Why

Long selections previously had to finish generating before playback could start. This makes Recite feel slower than it needs to, especially for articles or dense copied text.

## Validation

- `swift build`
- built and launched with `./scripts/build-and-run.sh`
- runtime smoke test with long clipboard text confirmed playback starts after the first generated chunk while later chunks keep generating