### PR TITLE
[codex] Default Recite launches to real code signing

### DIFF
--- a/scripts/build-and-run.sh
+++ b/scripts/build-and-run.sh
@@ -43,10 +43,19 @@ if [ -d "$MLX_METAL_SOURCES" ]; then
   rm -rf "$TMP_METAL_DIR"
 fi
 
-if [ -n "$REQUESTED_IDENTITY" ] && security find-identity -v -p codesigning | grep -Fq "$REQUESTED_IDENTITY"; then
+SIGNING_IDENTITIES="$(security find-identity -v -p codesigning)"
+if [ -n "$REQUESTED_IDENTITY" ] && echo "$SIGNING_IDENTITIES" | grep -Fq "$REQUESTED_IDENTITY"; then
   SIGN_IDENTITY="$REQUESTED_IDENTITY"
 else
-  SIGN_IDENTITY="-"
+  # Prefer a certificate hash so duplicate keychain identities do not make
+  # codesign fail with an "ambiguous" identity error.
+  SIGN_IDENTITY="$(echo "$SIGNING_IDENTITIES" | awk '/Developer ID Application: Justin Betker/ { print $2; exit }')"
+  if [ -z "$SIGN_IDENTITY" ]; then
+    SIGN_IDENTITY="$(echo "$SIGNING_IDENTITIES" | awk '/Apple Development: Justin Betker/ { print $2; exit }')"
+  fi
+  if [ -z "$SIGN_IDENTITY" ]; then
+    SIGN_IDENTITY="-"
+  fi
 fi
 
 echo "==> Signing with: $SIGN_IDENTITY"

--- a/scripts/build-and-run.sh
+++ b/scripts/build-and-run.sh
@@ -5,6 +5,7 @@ PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 APP_DIR="$PROJECT_DIR/.build/debug/Recite.app"
 CONTENTS="$APP_DIR/Contents"
 REQUESTED_IDENTITY="${RECITE_CODESIGN_IDENTITY:-}"
+DEFAULT_IDENTITY="${RECITE_DEFAULT_CODESIGN_IDENTITY:-9E29C607772DECCED7EC4E3BCBC01DD492548ECE}"
 ENTITLEMENTS="$PROJECT_DIR/Recite/Resources/Recite.entitlements"
 RESOURCES="$PROJECT_DIR/Recite/Resources"
 MLX_METAL_SOURCES="$PROJECT_DIR/.build/checkouts/mlx-swift/Source/Cmlx/mlx-generated/metal"
@@ -46,6 +47,8 @@ fi
 SIGNING_IDENTITIES="$(security find-identity -v -p codesigning)"
 if [ -n "$REQUESTED_IDENTITY" ] && echo "$SIGNING_IDENTITIES" | grep -Fq "$REQUESTED_IDENTITY"; then
   SIGN_IDENTITY="$REQUESTED_IDENTITY"
+elif echo "$SIGNING_IDENTITIES" | grep -Fq "$DEFAULT_IDENTITY"; then
+  SIGN_IDENTITY="$DEFAULT_IDENTITY"
 else
   # Prefer a certificate hash so duplicate keychain identities do not make
   # codesign fail with an "ambiguous" identity error.


### PR DESCRIPTION
## Summary

- update the local build/run script to prefer a real Developer ID signing identity instead of silently falling back to ad-hoc signing
- pin the default Recite signing certificate hash so repeated local launches use the same code signing identity
- keep `RECITE_CODESIGN_IDENTITY` / `RECITE_DEFAULT_CODESIGN_IDENTITY` overrides available for local testing

## Why

Ad-hoc signed local builds make macOS treat Recite as a different app for Accessibility trust. Using the same bundle id, stable app path, and same Developer ID signing identity should avoid having to re-enable Accessibility on every relaunch.

## Validation

- ran `./scripts/build-and-run.sh`
- verified launched app signature uses `Developer ID Application: Justin Betker (XG6WL66WUQ)`
- verified Team ID is `XG6WL66WUQ`