### PR TITLE
Finalize Recite public release setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+name: Build
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  swift-build:
+    name: Swift build
+    runs-on: macos-15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install espeak-ng
+        run: brew install espeak-ng
+
+      - name: Build
+        run: swift build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   swift-build:
     name: Swift build
-    runs-on: macos-15
+    runs-on: macos-26
 
     steps:
       - name: Check out repository

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "local-deps/mlx-audio-swift"]
 	path = local-deps/mlx-audio-swift
 	url = https://github.com/r3dbars/mlx-audio-swift.git
-	branch = codex/recite-tts-manifest-fix

--- a/README.md
+++ b/README.md
@@ -41,12 +41,17 @@ Recite uses Kokoro 82M for the voice and Apple MLX to run it efficiently on Appl
 - Xcode or the Swift toolchain
 - Homebrew `espeak-ng`
 
+## Download
+
+Download the latest DMG from [GitHub Releases](https://github.com/r3dbars/recite/releases/latest).
+
+Recite is just starting out. If there is not a release yet, use the Quick Start steps below.
+
 ## Quick Start
 
 ```bash
-git clone https://github.com/r3dbars/recite.git
+git clone --recursive https://github.com/r3dbars/recite.git
 cd recite
-git submodule update --init --recursive
 brew install espeak-ng
 swift build
 ./scripts/build-and-run.sh

--- a/SETUP.md
+++ b/SETUP.md
@@ -3,7 +3,8 @@
 Recite is a Swift Package macOS app. The fastest path is:
 
 ```bash
-git submodule update --init --recursive
+git clone --recursive https://github.com/r3dbars/recite.git
+cd recite
 brew install espeak-ng
 swift build
 ./scripts/build-and-run.sh

--- a/scripts/build-and-run.sh
+++ b/scripts/build-and-run.sh
@@ -82,7 +82,7 @@ else
 fi
 
 echo "==> Signing with: $SIGN_IDENTITY"
-codesign --force --sign "$SIGN_IDENTITY" --entitlements "$ENTITLEMENTS" --deep "$APP_DIR"
+codesign --force --sign "$SIGN_IDENTITY" --options runtime --entitlements "$ENTITLEMENTS" --deep "$APP_DIR"
 
 echo "==> Verifying signature..."
 codesign -dvvv "$APP_DIR" 2>&1 | grep -E "Identifier|TeamIdentifier|Signature"

--- a/scripts/build-dmg.sh
+++ b/scripts/build-dmg.sh
@@ -7,6 +7,11 @@ DIST_DIR="$PROJECT_DIR/.build/dist"
 STAGING_DIR="$DIST_DIR/Recite-dmg"
 INFO_PLIST="$PROJECT_DIR/Recite/Resources/Info.plist"
 DMG_ICON="$PROJECT_DIR/Recite/Resources/DMGIcon.icns"
+REQUESTED_IDENTITY="${RECITE_CODESIGN_IDENTITY:-}"
+DEFAULT_IDENTITY="${RECITE_DEFAULT_CODESIGN_IDENTITY:-9E29C607772DECCED7EC4E3BCBC01DD492548ECE}"
+NOTARY_PROFILE="${RECITE_NOTARY_PROFILE:-}"
+SIGN_DMG="${RECITE_SIGN_DMG:-1}"
+STAPLE_DMG="${RECITE_STAPLE_DMG:-1}"
 
 VERSION="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$INFO_PLIST")"
 DMG_PATH="$DIST_DIR/Recite-$VERSION.dmg"
@@ -34,5 +39,27 @@ hdiutil create \
   -ov \
   -format UDZO \
   "$DMG_PATH"
+
+if [ "$SIGN_DMG" = "1" ]; then
+  SIGN_IDENTITY="${REQUESTED_IDENTITY:-$DEFAULT_IDENTITY}"
+  if [ -n "$SIGN_IDENTITY" ] && [ "$SIGN_IDENTITY" != "Ad Hoc" ]; then
+    echo "==> Signing DMG with: $SIGN_IDENTITY"
+    codesign --force --sign "$SIGN_IDENTITY" "$DMG_PATH"
+  else
+    echo "==> Skipping DMG signing because the app is ad-hoc signed."
+  fi
+fi
+
+if [ -n "$NOTARY_PROFILE" ]; then
+  echo "==> Submitting DMG for notarization with profile: $NOTARY_PROFILE"
+  xcrun notarytool submit "$DMG_PATH" \
+    --keychain-profile "$NOTARY_PROFILE" \
+    --wait
+
+  if [ "$STAPLE_DMG" = "1" ]; then
+    echo "==> Stapling notarization ticket"
+    xcrun stapler staple "$DMG_PATH"
+  fi
+fi
 
 echo "Created $DMG_PATH"


### PR DESCRIPTION
## Summary
- add a basic Swift build workflow for GitHub Actions
- make clone/setup instructions friendlier for public readers
- add a GitHub Releases download section
- remove side-branch tracking from the public submodule config
- harden signing and notarization support in the DMG script

## Verification
- swift build
- RECITE_NOTARY_PROFILE=Transcripted ./scripts/build-dmg.sh
- hdiutil verify .build/dist/Recite-0.1.0.dmg
- xcrun stapler validate .build/dist/Recite-0.1.0.dmg
- codesign --verify --deep --strict --verbose=2 .build/debug/Recite.app
- spctl -a -vv .build/debug/Recite.app
- bash -n scripts/build-and-run.sh && bash -n scripts/build-dmg.sh
- git diff --check