### PR TITLE
Bundle espeak-ng with Recite

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ Recite uses Kokoro 82M for the voice and Apple MLX to run it efficiently on Appl
 
 - macOS 14 Sonoma or newer
 - Apple Silicon Mac
-- Xcode or the Swift toolchain
-- Homebrew `espeak-ng`
+- No Homebrew install is needed for the DMG download.
 
 ## Download
 
@@ -56,6 +55,8 @@ brew install espeak-ng
 swift build
 ./scripts/build-and-run.sh
 ```
+
+Source builds use your local Homebrew `espeak-ng` to assemble the app bundle. The downloadable DMG bundles that helper for normal users.
 
 On first launch, Recite downloads the Kokoro voice model from Hugging Face. After that, reading text aloud runs locally on your Mac.
 

--- a/Recite/Resources/Info.plist
+++ b/Recite/Resources/Info.plist
@@ -2,44 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <!-- Accessibility permission — needed for global hotkey and text grabbing -->
-    <key>NSAppleEventsUsageDescription</key>
-    <string>Recite needs accessibility access to read selected text from any app.</string>
-
-    <key>NSAccessibilityUsageDescription</key>
-    <string>Recite needs accessibility access to read selected text from other applications.</string>
-
-    <key>CFBundleName</key>
-    <string>Recite</string>
-
-    <key>CFBundleDisplayName</key>
-    <string>Recite</string>
-
-    <key>CFBundleIdentifier</key>
-    <string>com.r3dbars.recite</string>
-
-    <key>CFBundleExecutable</key>
-    <string>Recite</string>
-
-    <key>CFBundleVersion</key>
-    <string>1</string>
-
-    <key>CFBundleShortVersionString</key>
-    <string>0.1.0</string>
-
-    <key>CFBundlePackageType</key>
-    <string>APPL</string>
-
-    <key>NSPrincipalClass</key>
-    <string>NSApplication</string>
-
-    <key>CFBundleIconFile</key>
-    <string>AppIcon</string>
-
-    <key>NSHighResolutionCapable</key>
-    <true/>
-
-    <key>LSMinimumSystemVersion</key>
-    <string>14.0</string>
+	<key>CFBundleDisplayName</key>
+	<string>Recite</string>
+	<key>CFBundleExecutable</key>
+	<string>Recite</string>
+	<key>CFBundleIconFile</key>
+	<string>AppIcon</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.r3dbars.recite</string>
+	<key>CFBundleName</key>
+	<string>Recite</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.1.1</string>
+	<key>CFBundleVersion</key>
+	<string>2</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>14.0</string>
+	<key>NSAccessibilityUsageDescription</key>
+	<string>Recite needs accessibility access to read selected text from other applications.</string>
+	<key>NSAppleEventsUsageDescription</key>
+	<string>Recite needs accessibility access to read selected text from any app.</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
 </dict>
 </plist>

--- a/Recite/Sources/Recite/SpeechEngine.swift
+++ b/Recite/Sources/Recite/SpeechEngine.swift
@@ -27,7 +27,7 @@ private enum EspeakTextProcessorError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case .missingExecutable:
-            return "espeak-ng was not found. Install it with `brew install espeak-ng`."
+            return "espeak-ng was not found."
         case let .failed(status, stderr):
             if stderr.isEmpty {
                 return "espeak-ng exited with status \(status)."
@@ -46,7 +46,25 @@ struct EspeakTextProcessor: TextProcessor {
     ]
 
     static var installedExecutablePath: String? {
-        executablePaths.first { FileManager.default.isExecutableFile(atPath: $0) }
+        if let bundled = bundledExecutableURL,
+           FileManager.default.isExecutableFile(atPath: bundled.path) {
+            return bundled.path
+        }
+        return executablePaths.first { FileManager.default.isExecutableFile(atPath: $0) }
+    }
+
+    private static var bundledExecutableURL: URL? {
+        Bundle.main.executableURL?
+            .deletingLastPathComponent()
+            .appendingPathComponent("espeak-ng")
+    }
+
+    private static var bundledDataParentURL: URL? {
+        guard let dataURL = Bundle.main.resourceURL?.appendingPathComponent("espeak-ng-data"),
+              FileManager.default.fileExists(atPath: dataURL.path) else {
+            return nil
+        }
+        return dataURL.deletingLastPathComponent()
     }
 
     func process(text: String, language: String?) throws -> String {
@@ -56,7 +74,13 @@ struct EspeakTextProcessor: TextProcessor {
         }
 
         process.executableURL = URL(fileURLWithPath: executablePath)
-        process.arguments = ["--ipa", "-q", text]
+        var arguments = ["--ipa", "-q"]
+        if executablePath == Self.bundledExecutableURL?.path,
+           let dataParentURL = Self.bundledDataParentURL {
+            arguments.append("--path=\(dataParentURL.path)")
+        }
+        arguments.append(text)
+        process.arguments = arguments
 
         let pipe = Pipe()
         let errorPipe = Pipe()

--- a/SETUP.md
+++ b/SETUP.md
@@ -15,8 +15,10 @@ swift build
 - macOS 14 Sonoma or newer
 - Apple Silicon Mac
 - Xcode or the Swift toolchain
-- Homebrew
-- `espeak-ng`
+- Homebrew for source builds
+- `espeak-ng` for assembling a local app bundle from source
+
+People who install the DMG do not need Homebrew or a separate `espeak-ng` install.
 
 ## First Launch
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,15 @@
+# Third-Party Notices
+
+Recite bundles a small `espeak-ng` runtime in release app bundles so people can install the app without Homebrew.
+
+## eSpeak NG
+
+- Project: https://github.com/espeak-ng/espeak-ng
+- Purpose: pronunciation and phoneme generation before Kokoro creates the final voice audio
+- License: GPL-3.0-or-later, with additional notices in the upstream project
+
+## pcaudiolib
+
+- Project: https://github.com/espeak-ng/pcaudiolib
+- Purpose: runtime library used by the bundled `espeak-ng` command-line tool
+- License: GPL-3.0-or-later

--- a/scripts/build-and-run.sh
+++ b/scripts/build-and-run.sh
@@ -4,11 +4,14 @@ set -euo pipefail
 PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 APP_DIR="$PROJECT_DIR/.build/debug/Recite.app"
 CONTENTS="$APP_DIR/Contents"
+MACOS="$CONTENTS/MacOS"
+FRAMEWORKS="$CONTENTS/Frameworks"
 REQUESTED_IDENTITY="${RECITE_CODESIGN_IDENTITY:-}"
 DEFAULT_IDENTITY="${RECITE_DEFAULT_CODESIGN_IDENTITY:-9E29C607772DECCED7EC4E3BCBC01DD492548ECE}"
 ENTITLEMENTS="$PROJECT_DIR/Recite/Resources/Recite.entitlements"
 RESOURCES="$PROJECT_DIR/Recite/Resources"
 MLX_METAL_SOURCES="$PROJECT_DIR/.build/checkouts/mlx-swift/Source/Cmlx/mlx-generated/metal"
+ESPEAK_PREFIX="${RECITE_ESPEAK_PREFIX:-}"
 LAUNCH_APP=1
 
 for arg in "$@"; do
@@ -39,12 +42,55 @@ fi
 
 echo "==> Assembling app bundle..."
 rm -rf "$APP_DIR"
-mkdir -p "$CONTENTS/MacOS" "$CONTENTS/Resources"
+mkdir -p "$MACOS" "$FRAMEWORKS" "$CONTENTS/Resources"
 
-cp "$PROJECT_DIR/.build/debug/Recite" "$CONTENTS/MacOS/Recite"
+cp "$PROJECT_DIR/.build/debug/Recite" "$MACOS/Recite"
 cp "$RESOURCES/Info.plist" "$CONTENTS/Info.plist"
 cp "$RESOURCES"/AppIcon.icns "$CONTENTS/Resources/" 2>/dev/null || true
 cp "$RESOURCES"/MenuBarIcon*.png "$CONTENTS/Resources/" 2>/dev/null || true
+
+if [ -z "$ESPEAK_PREFIX" ]; then
+  ESPEAK_PREFIX="$(brew --prefix espeak-ng 2>/dev/null || true)"
+fi
+PCAUDIO_PREFIX="$(brew --prefix pcaudiolib 2>/dev/null || true)"
+
+if [ -n "$ESPEAK_PREFIX" ] && [ -x "$ESPEAK_PREFIX/bin/espeak-ng" ]; then
+  echo "==> Bundling espeak-ng..."
+  cp "$ESPEAK_PREFIX/bin/espeak-ng" "$MACOS/espeak-ng"
+  cp "$ESPEAK_PREFIX/lib/libespeak-ng.1.dylib" "$FRAMEWORKS/libespeak-ng.1.dylib"
+  if [ -n "$PCAUDIO_PREFIX" ] && [ -f "$PCAUDIO_PREFIX/lib/libpcaudio.0.dylib" ]; then
+    cp "$PCAUDIO_PREFIX/lib/libpcaudio.0.dylib" "$FRAMEWORKS/libpcaudio.0.dylib"
+  fi
+  cp -R "$ESPEAK_PREFIX/share/espeak-ng-data" "$CONTENTS/Resources/espeak-ng-data"
+  mkdir -p "$CONTENTS/Resources/ThirdParty/espeak-ng" "$CONTENTS/Resources/ThirdParty/pcaudiolib"
+  cp "$PROJECT_DIR/THIRD_PARTY_NOTICES.md" "$CONTENTS/Resources/ThirdParty/" 2>/dev/null || true
+  cp "$ESPEAK_PREFIX"/COPYING* "$CONTENTS/Resources/ThirdParty/espeak-ng/" 2>/dev/null || true
+  cp "$ESPEAK_PREFIX"/README.md "$CONTENTS/Resources/ThirdParty/espeak-ng/" 2>/dev/null || true
+  if [ -n "$PCAUDIO_PREFIX" ]; then
+    cp "$PCAUDIO_PREFIX"/COPYING "$CONTENTS/Resources/ThirdParty/pcaudiolib/" 2>/dev/null || true
+    cp "$PCAUDIO_PREFIX"/README* "$CONTENTS/Resources/ThirdParty/pcaudiolib/" 2>/dev/null || true
+  fi
+
+  ESPEAK_LIB_REF="$(otool -L "$MACOS/espeak-ng" | awk '/libespeak-ng\.1\.dylib/ { print $1; exit }')"
+  PCAUDIO_LIB_REF_IN_HELPER="$(otool -L "$MACOS/espeak-ng" | awk '/libpcaudio\.0\.dylib/ { print $1; exit }')"
+  PCAUDIO_LIB_REF_IN_ESPEAK="$(otool -L "$FRAMEWORKS/libespeak-ng.1.dylib" | awk '/libpcaudio\.0\.dylib/ { print $1; exit }')"
+
+  install_name_tool \
+    -change "$ESPEAK_LIB_REF" "@executable_path/../Frameworks/libespeak-ng.1.dylib" \
+    -change "$PCAUDIO_LIB_REF_IN_HELPER" "@executable_path/../Frameworks/libpcaudio.0.dylib" \
+    "$MACOS/espeak-ng"
+
+  install_name_tool \
+    -id "@executable_path/../Frameworks/libespeak-ng.1.dylib" \
+    -change "$PCAUDIO_LIB_REF_IN_ESPEAK" "@loader_path/libpcaudio.0.dylib" \
+    "$FRAMEWORKS/libespeak-ng.1.dylib"
+
+  if [ -f "$FRAMEWORKS/libpcaudio.0.dylib" ]; then
+    install_name_tool -id "@rpath/libpcaudio.0.dylib" "$FRAMEWORKS/libpcaudio.0.dylib"
+  fi
+else
+  echo "==> espeak-ng not found locally; app will use a system Homebrew install if available."
+fi
 
 if [ -d "$MLX_METAL_SOURCES" ]; then
   echo "==> Compiling MLX Metal kernels..."
@@ -57,7 +103,7 @@ if [ -d "$MLX_METAL_SOURCES" ]; then
     AIR_FILES+=("$air")
   done < <(find "$MLX_METAL_SOURCES" -name '*.metal' -print0)
   if [ "${#AIR_FILES[@]}" -gt 0 ]; then
-    xcrun -sdk macosx metallib "${AIR_FILES[@]}" -o "$CONTENTS/MacOS/mlx.metallib"
+    xcrun -sdk macosx metallib "${AIR_FILES[@]}" -o "$MACOS/mlx.metallib"
   else
     echo "==> No MLX Metal kernels found."
   fi
@@ -82,6 +128,15 @@ else
 fi
 
 echo "==> Signing with: $SIGN_IDENTITY"
+if [ -f "$FRAMEWORKS/libpcaudio.0.dylib" ]; then
+  codesign --force --sign "$SIGN_IDENTITY" --options runtime "$FRAMEWORKS/libpcaudio.0.dylib"
+fi
+if [ -f "$FRAMEWORKS/libespeak-ng.1.dylib" ]; then
+  codesign --force --sign "$SIGN_IDENTITY" --options runtime "$FRAMEWORKS/libespeak-ng.1.dylib"
+fi
+if [ -x "$MACOS/espeak-ng" ]; then
+  codesign --force --sign "$SIGN_IDENTITY" --options runtime "$MACOS/espeak-ng"
+fi
 codesign --force --sign "$SIGN_IDENTITY" --options runtime --entitlements "$ENTITLEMENTS" --deep "$APP_DIR"
 
 echo "==> Verifying signature..."


### PR DESCRIPTION
## Summary
- bundle espeak-ng, libespeak-ng, pcaudiolib, and espeak-ng-data into the app bundle
- make Recite prefer the bundled helper and pass the bundled data path
- include third-party notices/license files in the app bundle
- update docs so DMG users know Homebrew is not required
- bump app version to 0.1.1

## Verification
- swift build
- ./scripts/build-and-run.sh --no-launch
- bundled espeak-ng phoneme smoke test from Recite.app
- RECITE_NOTARY_PROFILE=Transcripted ./scripts/build-dmg.sh
- hdiutil verify .build/dist/Recite-0.1.1.dmg
- xcrun stapler validate .build/dist/Recite-0.1.1.dmg
- codesign --verify --deep --strict --verbose=2 .build/debug/Recite.app
- spctl -a -vv .build/debug/Recite.app
- git diff --check