### PR TITLE
[codex] Improve Recite selection and text cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,28 @@ Recite does it locally instead. It downloads a small AI voice model once, then u
 
 Recite uses Kokoro 82M for the voice and Apple MLX to run it efficiently on Apple Silicon Macs.
 
+## Model And Voices
+
+Recite uses [Kokoro-82M-bf16](https://huggingface.co/mlx-community/Kokoro-82M-bf16), an MLX conversion of [hexgrad/Kokoro-82M](https://huggingface.co/hexgrad/Kokoro-82M). The model is about 355 MB, downloads once on first launch, and runs on your Mac.
+
+Recite includes 13 English voice presets:
+
+| Name | Voice ID | Accent |
+| --- | --- | --- |
+| Heart | `af_heart` | American female |
+| Bella | `af_bella` | American female |
+| Sky | `af_sky` | American female |
+| Nicole | `af_nicole` | American female |
+| Sarah | `af_sarah` | American female |
+| Nova | `af_nova` | American female |
+| River | `af_river` | American female |
+| Adam | `am_adam` | American male |
+| Michael | `am_michael` | American male |
+| Eric | `am_eric` | American male |
+| Liam | `am_liam` | American male |
+| Alice | `bf_alice` | British female |
+| Daniel | `bm_daniel` | British male |
+
 ## Requirements
 
 - macOS 14 Sonoma or newer

--- a/Recite/Sources/Recite/AppDelegate.swift
+++ b/Recite/Sources/Recite/AppDelegate.swift
@@ -1,16 +1,57 @@
 import AppKit
 import SwiftUI
 import Combine
+import ApplicationServices
+import Carbon.HIToolbox
 import os.log
 
 private let log = Logger(subsystem: "com.r3dbars.recite", category: "AppDelegate")
 private let didShowFirstLaunchWindowKey = "didShowFirstLaunchWindow"
+private let reciteHotKeySignature: OSType = 0x52435445
+
+private func sourcePIDFromFrontmostApp() -> pid_t? {
+    let frontmost = NSWorkspace.shared.frontmostApplication
+    if frontmost?.bundleIdentifier == Bundle.main.bundleIdentifier {
+        return nil
+    }
+    return frontmost?.processIdentifier
+}
+
+private func selectedTextFromFocusedElement(pid: pid_t) -> String? {
+    guard AXIsProcessTrusted() else { return nil }
+
+    let axApp = AXUIElementCreateApplication(pid)
+    var focusedElement: AnyObject?
+    let focusResult = AXUIElementCopyAttributeValue(
+        axApp,
+        kAXFocusedUIElementAttribute as CFString,
+        &focusedElement
+    )
+    guard focusResult == .success, let element = focusedElement else {
+        return nil
+    }
+    guard CFGetTypeID(element) == AXUIElementGetTypeID() else {
+        return nil
+    }
+
+    var selectedText: AnyObject?
+    let selectedResult = AXUIElementCopyAttributeValue(
+        element as! AXUIElement,
+        kAXSelectedTextAttribute as CFString,
+        &selectedText
+    )
+    guard selectedResult == .success else {
+        return nil
+    }
+    return selectedText as? String
+}
 
 @MainActor
 class AppDelegate: NSObject, NSApplicationDelegate {
     private var statusItem: NSStatusItem!
     private var popover: NSPopover!
-    private var eventMonitor: Any?
+    private var carbonHotKeyRef: EventHotKeyRef?
+    private var carbonEventHandlerRef: EventHandlerRef?
     private var localEventMonitor: Any?
     private var workspaceObserver: Any?
     private var mainWindow: NSWindow?
@@ -42,8 +83,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         Task { @MainActor in
             engine.stop()
         }
-        if let monitor = eventMonitor {
-            NSEvent.removeMonitor(monitor)
+        if let ref = carbonHotKeyRef {
+            UnregisterEventHotKey(ref)
+        }
+        if let handler = carbonEventHandlerRef {
+            RemoveEventHandler(handler)
         }
         if let monitor = localEventMonitor {
             NSEvent.removeMonitor(monitor)
@@ -224,41 +268,98 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func requestAccessibilityAndSetupHotKey() {
         grabber.requestAccessibilityPermission()
-        // Register hotkey immediately — local monitor works without Accessibility.
-        // Global monitor (other-app events) requires Accessibility but we register
-        // it now too; macOS will silently drop events until permission is granted.
         setupGlobalHotKey()
     }
 
     private func setupGlobalHotKey() {
-        guard eventMonitor == nil else { return }
+        guard carbonHotKeyRef == nil else { return }
 
-        let handler: (NSEvent) -> Bool = { [weak self] event in
-            // Mask to device-independent flags only — macOS injects extra bits
-            // (.numericPad, .function, etc.) that break a naive .contains() check.
-            let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-            guard event.keyCode == 15, flags == [.control, .option] else { return false }
-            log.info("⌃⌥R pressed — hotkey triggered (keyCode=\(event.keyCode))")
-            let frontmostApp = NSWorkspace.shared.frontmostApplication
-            let sourcePID = frontmostApp?.bundleIdentifier == Bundle.main.bundleIdentifier
-                ? nil
-                : frontmostApp?.processIdentifier
-            log.info("Source app PID: \(sourcePID ?? 0)")
-            Task { @MainActor in
-                self?.readSelection(sourcePID: sourcePID)
-            }
-            return true
+        var eventType = EventTypeSpec(
+            eventClass: OSType(kEventClassKeyboard),
+            eventKind: UInt32(kEventHotKeyPressed)
+        )
+        let handlerStatus = InstallEventHandler(
+            GetApplicationEventTarget(),
+            { _, event, userData -> OSStatus in
+                guard let event, let userData else {
+                    return OSStatus(eventNotHandledErr)
+                }
+
+                var hotKeyID = EventHotKeyID()
+                GetEventParameter(
+                    event,
+                    EventParamName(kEventParamDirectObject),
+                    EventParamType(typeEventHotKeyID),
+                    nil,
+                    MemoryLayout<EventHotKeyID>.size,
+                    nil,
+                    &hotKeyID
+                )
+                guard hotKeyID.signature == reciteHotKeySignature, hotKeyID.id == 1 else {
+                    return OSStatus(eventNotHandledErr)
+                }
+
+                let delegate = Unmanaged<AppDelegate>.fromOpaque(userData).takeUnretainedValue()
+                let sourcePID = sourcePIDFromFrontmostApp()
+                let axText = sourcePID.flatMap(selectedTextFromFocusedElement(pid:))
+
+                Task { @MainActor in
+                    delegate.hotkeyFired(sourcePID: sourcePID, axText: axText)
+                }
+                return noErr
+            },
+            1,
+            &eventType,
+            Unmanaged.passUnretained(self).toOpaque(),
+            &carbonEventHandlerRef
+        )
+        guard handlerStatus == noErr else {
+            log.error("Failed to install Carbon hotkey handler: \(handlerStatus)")
+            return
         }
 
-        // Global monitor fires when another app is active (requires Accessibility).
-        eventMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { event in
-            _ = handler(event)
+        let hotKeyID = EventHotKeyID(signature: reciteHotKeySignature, id: 1)
+        let registerStatus = RegisterEventHotKey(
+            UInt32(kVK_ANSI_R),
+            UInt32(controlKey | optionKey),
+            hotKeyID,
+            GetApplicationEventTarget(),
+            0,
+            &carbonHotKeyRef
+        )
+        guard registerStatus == noErr else {
+            log.error("Failed to register Carbon hotkey: \(registerStatus)")
+            return
         }
-        // Local monitor fires when Recite itself is active.
+
         localEventMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
-            handler(event) ? nil : event
+            let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            guard event.keyCode == 15, flags == [.control, .option] else {
+                return event
+            }
+            Task { @MainActor in
+                self.hotkeyFired(sourcePID: self.lastExternalApp?.processIdentifier, axText: nil)
+            }
+            return nil
         }
-        log.info("Global hotkey registered (eventMonitor=\(self.eventMonitor != nil))")
+        log.info("Carbon hotkey registered: ⌃⌥R")
+    }
+
+    @MainActor
+    private func hotkeyFired(sourcePID: pid_t?, axText: String?) {
+        let trimmedAXText = axText?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if !trimmedAXText.isEmpty {
+            log.info("Hotkey used synchronous AX text (\(trimmedAXText.count) chars)")
+            showPopover()
+            let item = queue.add(text: trimmedAXText, source: "Selection")
+            if engine.state == .idle {
+                queue.play(item: item)
+            }
+            return
+        }
+
+        log.info("Hotkey falling back to clipboard simulation for pid \(sourcePID ?? 0)")
+        readSelection(sourcePID: sourcePID)
     }
 
     private func showPopover() {

--- a/Recite/Sources/Recite/SpeechEngine.swift
+++ b/Recite/Sources/Recite/SpeechEngine.swift
@@ -544,24 +544,69 @@ class SpeechEngine: NSObject, ObservableObject {
         return max(lowWaterAudioSeconds + expectedDrain, Self.comfortableStartupBufferSeconds * playbackRate)
     }
 
-    /// Clean raw text before TTS — strips Slack noise, timestamps, emoji codes, file attachments.
+    /// Normalize raw text before TTS — strips markup/noise and preserves paragraph pauses.
     private func preprocessText(_ text: String) -> String {
         var s = text
 
-        func re(_ pattern: String, _ replacement: String, multiline: Bool = false) {
-            var opts: NSRegularExpression.Options = []
-            if multiline { opts.insert(.anchorsMatchLines) }
-            guard let rx = try? NSRegularExpression(pattern: pattern, options: opts) else { return }
+        func re(_ pattern: String, _ replacement: String, options: NSRegularExpression.Options = []) {
+            guard let rx = try? NSRegularExpression(pattern: pattern, options: options) else { return }
             let full = NSRange(s.startIndex..., in: s)
             s = rx.stringByReplacingMatches(in: s, range: full, withTemplate: replacement)
         }
+
+        let rawLines = s.components(separatedBy: "\n")
+        var normalizedLines: [String] = []
+        for (index, line) in rawLines.enumerated() {
+            normalizedLines.append(line)
+            guard index < rawLines.count - 1 else { continue }
+            let current = line.trimmingCharacters(in: .whitespaces)
+            let next = rawLines[index + 1].trimmingCharacters(in: .whitespaces)
+            if !current.isEmpty && !next.isEmpty {
+                normalizedLines.append("")
+            }
+        }
+        s = normalizedLines.joined(separator: "\n")
+
+        // Markdown and common rich-text leftovers.
+        re("```[\\s\\S]*?```", " ", options: .dotMatchesLineSeparators)
+        re("~~~[\\s\\S]*?~~~", " ", options: .dotMatchesLineSeparators)
+        re("`([^`\\n]+)`", "$1")
+        re("!\\[[^\\]]*\\]\\([^)]*\\)", "")
+        re("\\[([^\\]]+)\\]\\([^)]*\\)", "$1")
+        re("^#{1,6}\\s+", "", options: .anchorsMatchLines)
+        re("\\*{3}([^*\\n]+)\\*{3}", "$1")
+        re("_{3}([^_\\n]+)_{3}", "$1")
+        re("\\*{2}([^*\\n]+)\\*{2}", "$1")
+        re("_{2}([^_\\n]+)_{2}", "$1")
+        re("\\*([^*\\n]+)\\*", "$1")
+        re("_([^_\\n]+)_", "$1")
+        re("~~([^~\\n]+)~~", "$1")
+        re("^[-*_=]{3,}\\s*$", "", options: .anchorsMatchLines)
+        re("^>+\\s*", "", options: .anchorsMatchLines)
+        re("^[|\\-:\\s]+$", "", options: .anchorsMatchLines)
+        re("\\|", " ")
+        re("^[\\-\\*\\+]\\s+", "", options: .anchorsMatchLines)
+        re("^\\d+[.)\\s]\\s*", "", options: .anchorsMatchLines)
+
+        s = s.components(separatedBy: "\n").map { line -> String in
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty else { return "" }
+            guard let last = trimmed.last else { return trimmed }
+            if ".!?".contains(last) {
+                return trimmed
+            }
+            if ",:;".contains(last) {
+                return String(trimmed.dropLast()) + "."
+            }
+            return trimmed + "."
+        }.joined(separator: "\n")
 
         // Slack timestamps: [9:19 AM]
         re(#"\[\d{1,2}:\d{2}\s*(AM|PM)\]"#, "")
         // Slack emoji codes: :thankyoured:
         re(#":\w[\w+\-]*:"#, "")
         // File attachment lines: "Binary splunkd.log", "Zip JAMF…", "Image …", "Screenshot …"
-        re(#"^(Binary|Zip|Image|PDF|File|Screenshot)\s+\S+.*$"#, "", multiline: true)
+        re(#"^(Binary|Zip|Image|PDF|File|Screenshot)\s+\S+.*$"#, "", options: .anchorsMatchLines)
         // URLs
         re(#"https?://\S+"#, "link")
         re(#"\b\w+\.\w{2,4}/\S*"#, "link")
@@ -571,35 +616,42 @@ class SpeechEngine: NSObject, ObservableObject {
         return s.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    /// Split cleaned text into TTS-safe chunks.
-    /// Rules: split on sentence boundaries, but avoid splitting on abbreviations,
-    /// timestamps, decimals, or mid-word periods. Chunks are capped at ~400 chars
-    /// to stay well within Kokoro's 510-token limit.
+    /// Split cleaned text into TTS-safe chunks without crossing paragraph boundaries.
     private func splitIntoSentences(_ text: String) -> [String] {
         let cleaned = preprocessText(text)
-        let maxChunkChars = 400
         guard !cleaned.isEmpty else { return [] }
+
+        let paragraphs = cleaned.components(separatedBy: "\n\n")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+
+        return paragraphs.flatMap { splitParagraph($0) }
+    }
+
+    /// Split one paragraph on sentence boundaries, capped for Kokoro's token limit.
+    private func splitParagraph(_ text: String) -> [String] {
+        let maxChunkChars = 400
 
         // Use NSLinguisticTagger for sentence boundary detection — handles
         // abbreviations, "Mr.", decimals, and URLs far better than naive punctuation split.
         var chunks: [String] = []
         let tagger = NSLinguisticTagger(tagSchemes: [.tokenType], options: 0)
-        tagger.string = cleaned
+        tagger.string = text
 
         var sentences: [String] = []
-        let range = NSRange(cleaned.startIndex..., in: cleaned)
+        let range = NSRange(text.startIndex..., in: text)
         tagger.enumerateTags(in: range,
                              unit: .sentence,
                              scheme: .tokenType,
                              options: []) { _, tokenRange, _ in
-            if let r = Range(tokenRange, in: cleaned) {
-                let s = String(cleaned[r]).trimmingCharacters(in: .whitespacesAndNewlines)
+            if let r = Range(tokenRange, in: text) {
+                let s = String(text[r]).trimmingCharacters(in: .whitespacesAndNewlines)
                 if !s.isEmpty { sentences.append(s) }
             }
         }
 
         // Fallback: if tagger produced nothing (very short text), use the whole thing
-        if sentences.isEmpty { return splitByWords(cleaned, maxChars: maxChunkChars) }
+        if sentences.isEmpty { return splitByWords(text, maxChars: maxChunkChars) }
 
         // Merge very short sentences into the previous chunk, split oversized ones
         var current = ""

--- a/Recite/Sources/Recite/TextGrabber.swift
+++ b/Recite/Sources/Recite/TextGrabber.swift
@@ -44,7 +44,7 @@ class TextGrabber: ObservableObject {
         }
         log.info("Accessibility returned nothing, falling back to clipboard simulation")
 
-        let clipText = await getTextViaClipboard()
+        let clipText = await getTextViaClipboard(pid: pid)
         if let clipText, !clipText.isEmpty {
             log.info("Got text via clipboard (\(clipText.count) chars)")
             return clipText
@@ -108,9 +108,9 @@ class TextGrabber: ObservableObject {
 
     // MARK: - Clipboard Simulation
 
-    private func getTextViaClipboard() async -> String? {
+    private func getTextViaClipboard(pid: pid_t?) async -> String? {
         let pasteboard = NSPasteboard.general
-        log.info("Starting clipboard simulation")
+        log.info("Starting clipboard simulation for pid \(pid ?? 0)")
 
         let savedItems = pasteboard.pasteboardItems?.map(ClipboardItemSnapshot.init) ?? []
         log.info("Saved clipboard items=\(savedItems.count)")
@@ -125,15 +125,24 @@ class TextGrabber: ObservableObject {
         let src = CGEventSource(stateID: .hidSystemState)
         log.info("CGEventSource created: \(src != nil)")
 
+        func post(_ event: CGEvent?) {
+            guard let event else { return }
+            if let pid, pid > 0 {
+                event.postToPid(pid)
+            } else {
+                event.post(tap: .cghidEventTap)
+            }
+        }
+
         // Key code 8 = C
         let cDown = CGEvent(keyboardEventSource: src, virtualKey: 0x08, keyDown: true)
         cDown?.flags = .maskCommand
-        cDown?.post(tap: .cghidEventTap)
+        post(cDown)
         log.info("Posted ⌘C keyDown")
 
         let cUp = CGEvent(keyboardEventSource: src, virtualKey: 0x08, keyDown: false)
         cUp?.flags = .maskCommand
-        cUp?.post(tap: .cghidEventTap)
+        post(cUp)
         log.info("Posted ⌘C keyUp")
 
         // Give the source app a moment to process the ⌘C


### PR DESCRIPTION
## Summary

This cherry-picks the useful parts of Josh's Recite changes without merging the stale fork wholesale.

- Register the global read-selection hotkey with Carbon so Recite can capture the source app before focus changes.
- Try synchronous Accessibility selected-text capture from the source app, then fall back to a PID-targeted Command-C simulation.
- Preserve the existing clipboard snapshot/restore behavior during fallback copy.
- Improve TTS text cleanup for Markdown, lists, links, tables, headings, and paragraph pauses.
- Add concise README details for Kokoro-82M and the built-in English voice presets.

## Notes

I intentionally left out the skip/seek controls because Josh's version stores the full sample buffer and does not fit cleanly with Recite's newer streaming playback path.

## Validation

- `git diff --check`
- `git submodule update --init --recursive`
- `swift build`