### PR TITLE
Release Recite 0.1.3

### DIFF
--- a/Recite/Resources/Info.plist
+++ b/Recite/Resources/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.2</string>
+	<string>0.1.3</string>
 	<key>CFBundleVersion</key>
-	<string>3</string>
+	<string>4</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>NSAccessibilityUsageDescription</key>


### PR DESCRIPTION
Prepares Recite 0.1.3.\n\nChanges:\n- Bumps CFBundleShortVersionString to 0.1.3.\n- Bumps CFBundleVersion to 4.\n\nVerification:\n- RECITE_NOTARY_PROFILE=Transcripted ./scripts/build-dmg.sh\n- xcrun stapler validate .build/dist/Recite-0.1.3.dmg\n- spctl -a -t open --context context:primary-signature -vv .build/dist/Recite-0.1.3.dmg\n- codesign --verify --deep --strict --verbose=2 .build/debug/Recite.app\n- spctl -a -t exec -vv .build/debug/Recite.app